### PR TITLE
Fix serializing of predictions

### DIFF
--- a/DNAnet/allele_callers.py
+++ b/DNAnet/allele_callers.py
@@ -54,10 +54,10 @@ class NearestBasePairCaller(AlleleCaller):
         if 'called_alleles_manual' in image.meta:
             # in this case we are working on ground truth annotations, remove DYS and AMEL
             # from the prediction as these markers are not present in the annotations
-            prediction.meta["called_alleles"] = \
+            prediction.called_alleles = \
                 [m for m in called_alleles if m.name not in NON_AUTOSOMAL_MARKERS]
         else:
-            prediction.meta["called_alleles"] = called_alleles
+            prediction.called_alleles = called_alleles
         return prediction
 
     def translate_pixels_to_alleles(

--- a/DNAnet/data/data_models/dna_models.py
+++ b/DNAnet/data/data_models/dna_models.py
@@ -39,6 +39,31 @@ class Allele:
         """
         return np.array([self.left_bin, self.right_bin])[:, np.newaxis]
 
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary representation of the Allele.
+        """
+        return {
+            "name": self.name,
+            "base_pair": self.base_pair,
+            "left_bin": self.left_bin,
+            "right_bin": self.right_bin,
+            "height": self.height
+        }
+
+    @classmethod
+    def from_dict(cls, allele_dict: Dict[str, Any]):
+        """
+        Creates an Allele instance from a dictionary representation.
+        """
+        return cls(
+            name=allele_dict['name'],
+            base_pair=allele_dict.get('base_pair'),
+            left_bin=allele_dict.get('left_bin'),
+            right_bin=allele_dict.get('right_bin'),
+            height=allele_dict.get('height')
+        )
+
 
 @dataclass
 class Marker:
@@ -59,6 +84,28 @@ class Marker:
         Returns True if the marker is autosomal (i.e., not AMEL or DYS-prefixed).
         """
         return not (self.name == "AMEL" or self.name.startswith("DYS"))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Returns a dictionary representation of the Marker.
+        """
+        return {
+            "dye_row": self.dye_row,
+            "name": self.name,
+            "alleles": [allele.to_dict() for allele in self.alleles]
+        }
+
+    @classmethod
+    def from_dict(cls, marker_dict: Dict[str, Any]):
+        """
+        Creates a Marker instance from a dictionary representation.
+        """
+        alleles = [Allele.from_dict(a) for a in marker_dict['alleles']]
+        return cls(
+            dye_row=marker_dict['dye_row'],
+            name=marker_dict['name'],
+            alleles=alleles
+        )
 
 
 class Panel:

--- a/DNAnet/evaluation/segmentation/allele_metrics.py
+++ b/DNAnet/evaluation/segmentation/allele_metrics.py
@@ -24,7 +24,7 @@ def allele_precision(
     for image, prediction in zip(images, predictions):
         # convert the list of markers to list of locus_allele name strings
         predicted_alleles = flatten_marker_list_to_locusallelename_list(
-            prediction.meta["called_alleles"], locus=locus_name, min_rfu=min_rfu,
+            prediction.called_alleles, locus=locus_name, min_rfu=min_rfu,
             low_or_high=low_or_high_threshold
         )
 
@@ -59,7 +59,7 @@ def allele_recall(
     for image, prediction in zip(images, predictions):
         # convert the list of markers to list of locus_allele name strings
         predicted_alleles = flatten_marker_list_to_locusallelename_list(
-            prediction.meta["called_alleles"], locus=locus_name, min_rfu=min_rfu,
+            prediction.called_alleles, locus=locus_name, min_rfu=min_rfu,
             low_or_high=low_or_high_threshold
         )
         annotated_alleles = flatten_marker_list_to_locusallelename_list(

--- a/DNAnet/models/prediction.py
+++ b/DNAnet/models/prediction.py
@@ -55,7 +55,7 @@ class Prediction:
             "classification": self.classification,
             "image": self.image.tolist() if (self.image is not None) else None,
             "original_image_path": str(self.original_image_path),
-            "called_alleles": [allele.to_dict() for allele in self.called_alleles] if self.called_alleles else None,
+            "called_alleles": [marker.to_dict() for marker in self.called_alleles] if self.called_alleles else None,
         }
 
     @classmethod
@@ -64,7 +64,7 @@ class Prediction:
             classification=data['classification'],
             image=np.array(data['image']),
             original_image_path=data['original_image_path'],
-            called_alleles=[Marker.from_dict(allele) for allele in data['called_alleles']] if data.get('called_alleles') else None,
+            called_alleles=[Marker.from_dict(marker) for marker in data['called_alleles']] if data.get('called_alleles') else None,
         )
 
     def __hash__(self):

--- a/DNAnet/models/prediction.py
+++ b/DNAnet/models/prediction.py
@@ -1,7 +1,10 @@
 from operator import itemgetter
-from typing import Any, Mapping, MutableMapping
+from typing import Mapping, Sequence, Optional
 
 import numpy as np
+
+from DNAnet.data.data_models import Marker
+from DNAnet.typing import PathLike
 
 
 class Prediction:
@@ -12,18 +15,21 @@ class Prediction:
         confidence scores.
     :param image: A matrix representing an image. To be used e.g. in
         segmentation tasks, where predictions are made at the pixel level
-    :param meta: A mapping where additional metadata about this prediction
-        can be stored.
+    :param original_image_path: The path to the original image file
+    :param called_alleles: A list of called alleles, which are instances of
+        the Marker class.
     """
 
     def __init__(self,
                  classification: Mapping[str, float] = None,
                  image: np.ndarray = None,
-                 meta: MutableMapping[str, Any] = None):
+                 original_image_path: PathLike = None,
+                 called_alleles: Optional[Sequence[Marker]] = None):
 
         self.classification = classification
         self.image = image
-        self.meta = meta or dict()
+        self.original_image_path = original_image_path
+        self.called_alleles = called_alleles
 
     @property
     def label(self) -> str:
@@ -48,7 +54,8 @@ class Prediction:
         return {
             "classification": self.classification,
             "image": self.image.tolist() if (self.image is not None) else None,
-            "meta": self.meta
+            "original_image_path": str(self.original_image_path),
+            "called_alleles": [allele.to_dict() for allele in self.called_alleles] if self.called_alleles else None,
         }
 
     @classmethod
@@ -56,7 +63,8 @@ class Prediction:
         return cls(
             classification=data['classification'],
             image=np.array(data['image']),
-            meta=data['meta']
+            original_image_path=data['original_image_path'],
+            called_alleles=[Marker.from_dict(allele) for allele in data['called_alleles']] if data.get('called_alleles') else None,
         )
 
     def __hash__(self):
@@ -67,10 +75,11 @@ class Prediction:
 
     def __str__(self) -> str:
         return f"Prediction(" \
-               f"classification={self.classification}, " \
-               f"image={self.image}, " \
-               f"meta={self.meta}" \
-               f")"
+            f"classification={self.classification}, " \
+            f"image={self.image}, " \
+            f"original_image_path={self.original_image_path}, " \
+            f"called_alleles={self.called_alleles if self.called_alleles else None}" \
+            f")"
 
     def __repr__(self) -> str:
         return str(self)

--- a/DNAnet/models/segmentation/human_analysis.py
+++ b/DNAnet/models/segmentation/human_analysis.py
@@ -26,8 +26,7 @@ class HumanAnalysis(Model):
         # remove DYS and AMEL as these are not in the ground truth annotations
         called_alleles = [m for m in image.meta['called_alleles_manual']
                           if m.name not in NON_AUTOSOMAL_MARKERS]
-        return Prediction(image=None, meta={'called_alleles': called_alleles,
-                                            'original_image_path': image.path})
+        return Prediction(image=None, called_alleles=called_alleles, original_image_path=image.path)
 
     def load(self, model_dir: PathLike):
         pass

--- a/DNAnet/models/segmentation/trainable_unet.py
+++ b/DNAnet/models/segmentation/trainable_unet.py
@@ -379,7 +379,8 @@ class DNANet_UNet(TrainableModel):
 
         predictions = [Prediction(
             image=self.sigmoid(pred_im).movedim(0, -1).cpu().detach().numpy(),
-            meta={'original_image_path': image.path}) for image, pred_im in zip(batch, y_pred)]
+            original_image_path=image.path)
+                for image, pred_im in zip(batch, y_pred)]
 
         if self.allele_caller:
             LOGGER.info("Calling alleles from predicted segmentation...")

--- a/create_paper_figures.py
+++ b/create_paper_figures.py
@@ -78,7 +78,7 @@ def get_alleles(
         Dict[str, Tuple[List[Marker], np.ndarray]]: A dictionary containing the called alleles and their corresponding binary segmentation maps.
     """
     # Get alleles and add bin info
-    prediction_alleles = prediction.meta["called_alleles"]
+    prediction_alleles = prediction.called_alleles if prediction.called_alleles else []
     if manual_alleles := image.meta.get("called_alleles_manual", None):
         analyst_alleles = manual_alleles
         ground_truth_alleles = image.meta["called_alleles"]

--- a/tests/evaluation/segmentation/test_allele_metrics.py
+++ b/tests/evaluation/segmentation/test_allele_metrics.py
@@ -33,7 +33,7 @@ def test_allele_metrics():
     marker_2 = Marker(name="Penta E", dye_row=0, alleles=[Allele("14"), Allele("15.1")])
     markers = [marker_1, marker_2]
     image = HIDImage(path="/dummypath", meta={"called_alleles": markers})
-    prediction = Prediction(meta={"called_alleles": [marker_1]})
+    prediction = Prediction(called_alleles=[marker_1])
 
     tp, fn, fp = 2, 2, 0
 

--- a/tests/models/test_prediction.py
+++ b/tests/models/test_prediction.py
@@ -1,0 +1,65 @@
+import numpy as np
+from pathlib import Path
+
+from DNAnet.data.data_models import Allele, Marker
+from DNAnet.models.prediction import Prediction
+
+
+def test_prediction_roundtrip_with_alleles():
+    classification = {"pos": 0.9, "neg": 0.1}
+    image = np.array([[0.1, 0.2], [0.3, 0.4]])
+    called_alleles = [
+        Marker(dye_row=0, name="AMEL", alleles=[Allele("X"), Allele("Y")])
+    ]
+    original_path = Path("/tmp/sample.hid")
+
+    pred = Prediction(
+        classification=classification,
+        image=image,
+        original_image_path=original_path,
+        called_alleles=called_alleles,
+    )
+
+    pred_dict = pred.to_dict()
+    expected_dict = {
+        "classification": classification,
+        "image": image.tolist(),
+        "original_image_path": str(original_path),
+        "called_alleles": [
+            {
+                "dye_row": 0,
+                "name": "AMEL",
+                "alleles": [
+                    {"name": "X", "base_pair": None, "left_bin": None, "right_bin": None, "height": None},
+                    {"name": "Y", "base_pair": None, "left_bin": None, "right_bin": None, "height": None},
+                ],
+            }
+        ],
+    }
+    assert pred_dict == expected_dict
+
+    restored = Prediction.from_dict(pred_dict)
+    assert restored.classification == classification
+    np.testing.assert_equal(restored.image, image)
+    assert Path(restored.original_image_path) == original_path
+    assert restored.called_alleles == called_alleles
+
+
+def test_prediction_roundtrip_without_called_alleles():
+    classification = {"pos": 1.0}
+    image = np.zeros((1, 2))
+    original_path = Path("/tmp/img.hid")
+    pred = Prediction(
+        classification=classification,
+        image=image,
+        original_image_path=original_path,
+    )
+
+    pred_dict = pred.to_dict()
+    assert pred_dict["called_alleles"] is None
+
+    restored = Prediction.from_dict(pred_dict)
+    assert restored.called_alleles is None
+    assert restored.classification == classification
+    np.testing.assert_equal(restored.image, image)
+    assert Path(restored.original_image_path) == original_path


### PR DESCRIPTION
This PR ensures that the Prediction data model can be reliably serialized to a dict and restored back, fixing an issue when running evaluate.py.