### PR TITLE
Update README to use `pdm sync` instead of `pdm install` for fresh installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ pip install pdm
 ```
 Then run the following command to install the dependencies:
 ```bash
-$ pdm install
+$ pdm sync
 ```
 
 Git LFS is used to track `.pt` (model) files. Make sure to [install Git LFS](https://git-lfs.com/) on your system. In order to retrieve the files from the remote run the following command:


### PR DESCRIPTION
The README currently suggests `pdm install`, but this leads to updates in the lockfile, when there are upstream changes (i.e. new versions of dependencies released).

To keep the dependencies pinned at the versions in the `pdm.lock` file, it is better to use the `pdm sync` command.

See https://pdm-project.org/en/latest/usage/lockfile/#install-the-packages-pinned-in-lock-file