### PR TITLE
Translate allele to scanpoint annotations and rename get_allele_info

### DIFF
--- a/DNAnet/data/data_models/dna_models.py
+++ b/DNAnet/data/data_models/dna_models.py
@@ -129,7 +129,7 @@ class Panel:
             raise ValueError("Cannot instantiate Panel object, since panel path nor panel contents "
                              "are provided.")
 
-    def get_allele_info(self, marker_name: str, allele_name: str) \
+    def get_allele_basepair_and_bins(self, marker_name: str, allele_name: str) \
             -> Tuple[float, float, float]:
         """
         Retrieve allele information for a given allele name and
@@ -150,7 +150,7 @@ class Panel:
         # could be rare allele. see if we can find the base (e.g. 21 for 21.1)
         if '.' in allele_name and len(allele_name.split('.')) == 2:
             base_allele, extra_base_pairs = allele_name.split('.')
-            mid, left, right = self.get_allele_info(marker_name, base_allele)
+            mid, left, right = self.get_allele_basepair_and_bins(marker_name, base_allele)
             return (mid + int(extra_base_pairs),
                     left + int(extra_base_pairs),
                     right + int(extra_base_pairs))

--- a/DNAnet/data/data_models/hid_dataset.py
+++ b/DNAnet/data/data_models/hid_dataset.py
@@ -7,6 +7,7 @@ from itertools import chain
 from pathlib import Path
 from typing import Dict, Generator, List, Optional, Set, Tuple, Union
 
+import numpy as np
 from tqdm import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
@@ -14,11 +15,13 @@ from DNAnet.data.caching import _load_cached_hf_data, write_to_hf_cache
 from DNAnet.data.data_models import Panel
 from DNAnet.data.data_models.base import InMemoryDataset, SimpleDataset
 from DNAnet.data.data_models.hid_image import HIDImage, Ladder
+from DNAnet.data.data_models.structs import AlleleAnnotation, ScanpointAnnotation
 from DNAnet.data.strategies.dataset_strategies import DatasetStrategy
 from DNAnet.data.strategies.kit_strategies.kit import Kit
 from DNAnet.data.strategies.kit_strategies.scaling_strategy import EPGScalingStrategy
 from DNAnet.data.strategies.sample_validation_strategy import SampleValidationStrategy
 from DNAnet.data.split import split_data_in_k_folds
+from DNAnet.data.strategies.strategy_registry import StrategyRegistry
 from DNAnet.typing import PathLike
 from DNAnet.utils import (
     get_noc_from_rd_file_name,
@@ -561,3 +564,32 @@ class HIDDataset(InMemoryDataset):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.serialize()})"
+
+    @staticmethod
+    def _translate_allele_to_scanpoint_annotation(allele_annotation: AlleleAnnotation, adjusted_panel: Panel, scaler: np.ndarray) -> ScanpointAnnotation:
+        """
+        Translates allele annotation to scanpoint annotation by finding the closest scanpoint indices for the left and right bins
+        of each allele using the provided scaler and adjusted panel. The entire allelic bin is annotated as 1.
+
+        All non annotated scanpoints are labeled as 0, while annotated scanpoints are labeled as 1.
+        The resulting scanpoint annotation is a binary matrix of shape (num_dyes, num_scanpoints)
+
+            :param allele_annotation: AlleleAnnotation object containing the allele annotations to be translated.
+            :param adjusted_panel: Panel object containing the adjusted panel information to be used for translation.
+            :param scaler: numpy array containing the scaler values to be used for finding the closest scanpoint indices.
+            :return: ScanpointAnnotation object containing the translated scanpoint annotation.
+        """
+        # TODO: do not hardcode amount of scanpoints
+        scanpoint_annotation = np.zeros((StrategyRegistry.get_kit().num_dyes, 4096), dtype=np.int8)
+        for locus in allele_annotation.annotation:
+            for allele in locus.alleles:
+                # for each allele, find the left and right bin of the allele using the panel that has been adjusted by the corresponding ladder.
+                bp, left_bin, right_bin = adjusted_panel.get_allele_basepair_and_bins(locus.name, allele.name)
+
+                # use the scaler to find the closest scanpoint indices for the left and right bins of the allele
+                left_scanpoint = np.argmin(np.abs(scaler - left_bin))
+                right_scanpoint = np.argmin(np.abs(scaler - right_bin))
+
+                scanpoint_annotation[locus.dye_row, left_scanpoint : right_scanpoint] = 1
+
+        return ScanpointAnnotation(annotation=scanpoint_annotation)

--- a/DNAnet/data/data_models/structs.py
+++ b/DNAnet/data/data_models/structs.py
@@ -7,13 +7,13 @@ from DNAnet.data.data_models.dna_models import Marker
 
 class AlleleAnnotation(BaseModel):
     annotation: List[Marker]
-    
+
     @model_validator(mode="before")
     @classmethod
     def validate_annotation_input(cls, data: dict):
         if isinstance(data, dict):
             value = data.get("annotation")
-            
+
             if isinstance(value, list) and not isinstance(value[0], Marker):
                 # Merge markers
                 markers: Dict[str, Marker] = {}
@@ -26,11 +26,11 @@ class AlleleAnnotation(BaseModel):
                             marker.alleles.extend(sample_marker.alleles)
                 return {"annotation": list(markers.values())}
         return data
-                        
+
 
 class ScanpointAnnotation(BaseModel):
-    annotation: pnp.Np2DArrayFp32
-    
+    annotation: pnp.Np2DArrayInt8 # annotations only store the class index, so int8 is sufficient
+
 Annotation = Annotated[Union[AlleleAnnotation, ScanpointAnnotation], Field(discriminator="type")]
 
 
@@ -39,5 +39,5 @@ class AllelePrediction(AlleleAnnotation):
 
 class ScanpointPrediction(ScanpointAnnotation):
     pass
-    
+
 Prediction = Annotated[Union[AllelePrediction, ScanpointPrediction], Field(discriminator="type")]

--- a/DNAnet/data/parsing/parse_annotations.py
+++ b/DNAnet/data/parsing/parse_annotations.py
@@ -4,11 +4,17 @@ import os
 from itertools import groupby
 from typing import Iterable, List, Optional, Sequence, Tuple
 
+import numpy as np
+
 from DNAnet.data.data_models import Allele, Marker, Panel
+from DNAnet.data.data_models.structs import AlleleAnnotation, ScanpointAnnotation
+from DNAnet.data.strategies.strategy_registry import StrategyRegistry
 from DNAnet.typing import PathLike
 
 
 LOGGER = logging.getLogger("dnanet")
+
+
 
 
 def parse_called_alleles(annotation_file_path: PathLike,
@@ -45,6 +51,36 @@ def parse_called_alleles(annotation_file_path: PathLike,
         return None
 
 
+def translate_allele_to_scanpoint_annotation(allele_annotation: AlleleAnnotation, adjusted_panel: Panel, scaler: np.ndarray) -> ScanpointAnnotation:
+    """
+    Translates allele annotation to scanpoint annotation by finding the closest scanpoint indices for the left and right bins
+    of each allele using the provided scaler and adjusted panel. The entire allelic bin is annotated as 1.
+
+    All non annotated scanpoints are labeled as 0, while annotated scanpoints are labeled as 1.
+    The resulting scanpoint annotation is a binary matrix of shape (num_dyes, num_scanpoints)
+
+        :param allele_annotation: AlleleAnnotation object containing the allele annotations to be translated.
+        :param adjusted_panel: Panel object containing the adjusted panel information to be used for translation.
+        :param scaler: numpy array containing the scaler values to be used for finding the closest scanpoint indices.
+        :return: ScanpointAnnotation object containing the translated scanpoint annotation.
+    """
+    # TODO: do not hardcode amount of scanpoints
+    scanpoint_annotation = np.zeros((StrategyRegistry.get_kit().num_dyes, 4096), dtype=np.int8)
+    for locus in allele_annotation.annotation:
+        for allele in locus.alleles:
+            # for each allele, find the left and right bin of the allele using the panel that has been adjusted by the corresponding ladder.
+            bp, left_bin, right_bin = adjusted_panel.get_allele_basepair_and_bins(locus.name, allele.name)
+
+            # use the scaler to find the closest scanpoint indices for the left and right bins of the allele
+            left_scanpoint = np.argmin(np.abs(scaler - left_bin))
+            right_scanpoint = np.argmin(np.abs(scaler - right_bin))
+
+            scanpoint_annotation[locus.dye_row, left_scanpoint : right_scanpoint] = 1
+
+    return ScanpointAnnotation(annotation=scanpoint_annotation)
+
+
+
 def _parse_annotations(panel: Panel, results, allele_cols, height_cols) \
         -> List[Marker]:
     """
@@ -59,7 +95,7 @@ def _parse_annotations(panel: Panel, results, allele_cols, height_cols) \
             marker = Marker(dye_row,
                             marker_name,
                             [Allele(allele_name,
-                                    *panel.get_allele_info(
+                                    *panel.get_allele_basepair_and_bins(
                                         marker_name, allele_name),
                                     float(result[height_col]))
                              for allele_col, height_col in

--- a/DNAnet/data/parsing/parse_annotations.py
+++ b/DNAnet/data/parsing/parse_annotations.py
@@ -51,34 +51,6 @@ def parse_called_alleles(annotation_file_path: PathLike,
         return None
 
 
-def translate_allele_to_scanpoint_annotation(allele_annotation: AlleleAnnotation, adjusted_panel: Panel, scaler: np.ndarray) -> ScanpointAnnotation:
-    """
-    Translates allele annotation to scanpoint annotation by finding the closest scanpoint indices for the left and right bins
-    of each allele using the provided scaler and adjusted panel. The entire allelic bin is annotated as 1.
-
-    All non annotated scanpoints are labeled as 0, while annotated scanpoints are labeled as 1.
-    The resulting scanpoint annotation is a binary matrix of shape (num_dyes, num_scanpoints)
-
-        :param allele_annotation: AlleleAnnotation object containing the allele annotations to be translated.
-        :param adjusted_panel: Panel object containing the adjusted panel information to be used for translation.
-        :param scaler: numpy array containing the scaler values to be used for finding the closest scanpoint indices.
-        :return: ScanpointAnnotation object containing the translated scanpoint annotation.
-    """
-    # TODO: do not hardcode amount of scanpoints
-    scanpoint_annotation = np.zeros((StrategyRegistry.get_kit().num_dyes, 4096), dtype=np.int8)
-    for locus in allele_annotation.annotation:
-        for allele in locus.alleles:
-            # for each allele, find the left and right bin of the allele using the panel that has been adjusted by the corresponding ladder.
-            bp, left_bin, right_bin = adjusted_panel.get_allele_basepair_and_bins(locus.name, allele.name)
-
-            # use the scaler to find the closest scanpoint indices for the left and right bins of the allele
-            left_scanpoint = np.argmin(np.abs(scaler - left_bin))
-            right_scanpoint = np.argmin(np.abs(scaler - right_bin))
-
-            scanpoint_annotation[locus.dye_row, left_scanpoint : right_scanpoint] = 1
-
-    return ScanpointAnnotation(annotation=scanpoint_annotation)
-
 
 
 def _parse_annotations(panel: Panel, results, allele_cols, height_cols) \

--- a/DNAnet/data/strategies/kit_strategies/kit.py
+++ b/DNAnet/data/strategies/kit_strategies/kit.py
@@ -31,6 +31,7 @@ class Kit:
     name: str
     size_standard: InternalSizeStandard
     panel: Panel
+    num_dyes: int = 6
     panel_path: Optional[Path] = None
     markers: Optional[Sequence[str]] = None
     description: Optional[str] = None
@@ -50,6 +51,7 @@ def get_standard_kit(kit_name: str) -> Kit:
         return Kit(
             name="PPF6C",
             size_standard=InternalSizeStandard.WEN_ILS,
+            num_dyes=6,
             panel_path=_POWER_PLEX_FUSION_6C_PANEL_PATH,
             panel=Panel(
                 _POWER_PLEX_FUSION_6C_PANEL_PATH
@@ -62,6 +64,7 @@ def get_standard_kit(kit_name: str) -> Kit:
         return Kit(
             name="GlobalFiler",
             size_standard=InternalSizeStandard.GENESCAN_600_LIZ,
+            num_dyes=6,
             panel_path=_GLOBALFILER_PANEL_PATH,
             panel=Panel(_GLOBALFILER_PANEL_PATH),
             markers=None,  # fill in with marker names for quick validation

--- a/create_paper_figures.py
+++ b/create_paper_figures.py
@@ -55,7 +55,7 @@ def add_bin_info(called_alleles: List[Marker], panel: Panel) -> List[Marker]:
     """
     for marker in called_alleles:
         for allele in marker.alleles:
-            bin_info = panel.get_allele_info(
+            bin_info = panel.get_allele_basepair_and_bins(
                 marker_name=marker.name, allele_name=allele.name
             )
             allele.base_pair, allele.left_bin, allele.right_bin = bin_info

--- a/scripts/select_ladder_for_images.py
+++ b/scripts/select_ladder_for_images.py
@@ -50,7 +50,7 @@ def get_best_ladder_path(image: HIDImage, default_panel: Panel) -> Optional[str]
         for marker in image.meta['called_alleles']:
             for allele in marker.alleles:
                 # for every annotated peak, find the allele bin in terms of base pairs
-                _, bp_left, bp_right = ladder._panel.get_allele_info(marker.name, allele.name)
+                _, bp_left, bp_right = ladder._panel.get_allele_basepair_and_bins(marker.name, allele.name)
                 # translate base pairs to pixels using the image's scaler
                 pix_left, pix_right = basepair_to_pixel(image.scaler, bp_left), \
                                       basepair_to_pixel(image.scaler, bp_right)

--- a/tests/data/parsing/test_parse_annotations.py
+++ b/tests/data/parsing/test_parse_annotations.py
@@ -1,7 +1,12 @@
+import numpy as np
 import pytest
 
 from DNAnet.data.data_models import Allele, Marker, Panel
+from DNAnet.data.data_models.structs import AlleleAnnotation
 from DNAnet.data.parsing import parse_called_alleles
+from DNAnet.data.parsing.parse_annotations import translate_allele_to_scanpoint_annotation
+from DNAnet.data.strategies.kit_strategies.kit import KitOptions, get_standard_kit
+from DNAnet.data.strategies.strategy_registry import StrategyRegistry
 
 
 def test_parse_called_alleles():
@@ -37,3 +42,18 @@ def test_parse_called_alleles():
                    height=16330.0)])]
 
     assert len(markers) == 27
+
+
+def test_translate_allele_to_scanpoint_annotation():
+    StrategyRegistry.configure_kit(get_standard_kit("PPF6C"))
+    panel = Panel(pytest.PANEL_PATH)
+    scaler = np.arange(4096)
+    annotation =  Marker(dye_row=0, name='AMEL', alleles=[
+        Allele(name='X', base_pair=81.5, left_bin=81.0, right_bin=82.0)])
+    allele_annotation = AlleleAnnotation(annotation=[annotation])
+
+    scanpoint_annotation = translate_allele_to_scanpoint_annotation(allele_annotation, adjusted_panel=panel, scaler=scaler)
+
+    assert scanpoint_annotation.annotation[0, 81:82].all() == 1
+    assert scanpoint_annotation.annotation[0, :81].all() == 0
+    assert scanpoint_annotation.annotation[0, 82:].all() == 0


### PR DESCRIPTION
Create a function to translate AlleleAnnotations to ScanpointAnnotations using the adjusted image and scaler.

Rename get_allele_info to get_allele_basepair_and_bins to state it's purpose more clearly