### PR TITLE
Add a per RFU metric

### DIFF
--- a/conf/evaluate/peaknet.yaml
+++ b/conf/evaluate/peaknet.yaml
@@ -29,6 +29,10 @@ callbacks:
   allele_metrics:
     _target_: dnanet.evaluation.callbacks.AlleleMetricsCallback
     allele_caller: ${evaluate.allele_caller}
+  per_rfu_outcomes:
+    _target_: dnanet.evaluation.callbacks.PerRFUOutcomeCallback
+    threshold: 0.5
+    filename: per_rfu_outcomes.csv
 
 # Output options
 save_predictions: false

--- a/conf/evaluate/peaknet.yaml
+++ b/conf/evaluate/peaknet.yaml
@@ -32,7 +32,7 @@ callbacks:
   per_rfu_outcomes:
     _target_: dnanet.evaluation.callbacks.PerRFUOutcomeCallback
     threshold: 0.5
-    filename: per_rfu_outcomes.csv
+    filename: per_rfu_outcomes.npz
 
 # Output options
 save_predictions: false

--- a/conf/evaluate/segmentation.yaml
+++ b/conf/evaluate/segmentation.yaml
@@ -36,7 +36,7 @@ callbacks:
   per_rfu_outcomes:
     _target_: dnanet.evaluation.callbacks.PerRFUOutcomeCallback
     threshold: 0.5
-    filename: per_rfu_outcomes.csv
+    filename: per_rfu_outcomes.npz
 
 # Output options
 save_predictions: false

--- a/conf/evaluate/segmentation.yaml
+++ b/conf/evaluate/segmentation.yaml
@@ -33,6 +33,10 @@ callbacks:
   allele_metrics:
     _target_: dnanet.evaluation.callbacks.AlleleMetricsCallback
     allele_caller: ${evaluate.allele_caller}
+  per_rfu_outcomes:
+    _target_: dnanet.evaluation.callbacks.PerRFUOutcomeCallback
+    threshold: 0.5
+    filename: per_rfu_outcomes.csv
 
 # Output options
 save_predictions: false

--- a/src/dnanet/evaluation/__init__.py
+++ b/src/dnanet/evaluation/__init__.py
@@ -11,6 +11,7 @@ from dnanet.evaluation.metrics import (
     AlleleRecall,
     AlleleF1Score,
     AllelePrecision,
+    PerRFUOutcomeMetric,
 )
 from dnanet.evaluation.allele_caller import AlleleCaller, NearestBasePairCaller
 
@@ -22,4 +23,5 @@ __all__ = [
     "AllelePrecision",
     "AlleleRecall",
     "AlleleF1Score",
+    "PerRFUOutcomeMetric",
 ]

--- a/src/dnanet/evaluation/callbacks.py
+++ b/src/dnanet/evaluation/callbacks.py
@@ -7,11 +7,12 @@ from pathlib import Path
 from collections.abc import Mapping, Sequence
 
 import numpy as np
+from loguru import logger
 from lightning import Callback
 
 from dnanet.core.annotation import AlleleAnnotation
 from dnanet.evaluation.metrics.allele import AlleleRecall, AlleleF1Score, AllelePrecision
-from dnanet.evaluation.metrics.per_RFU import PerRFUOutcomeMetric, write_rfu_outcome_csv
+from dnanet.evaluation.metrics.per_RFU import PerRFUOutcomeMetric, write_rfu_outcome_npz
 
 
 if TYPE_CHECKING:
@@ -148,7 +149,7 @@ class PerRFUOutcomeCallback(Callback):
     def __init__(
         self,
         threshold: float = 0.5,
-        filename: str = "per_rfu_outcomes.csv",
+        filename: str = "per_rfu_outcomes.npz",
         metric: PerRFUOutcomeMetric | None = None,
     ) -> None:
         """Initialize the RFU outcome callback."""
@@ -158,6 +159,7 @@ class PerRFUOutcomeCallback(Callback):
     def on_test_epoch_start(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
         """Reset RFU outcome state before a test epoch starts."""
         del trainer, pl_module
+        logger.warning("Per-RFU outcome logging may create large NPZ files.")
         self.metric.reset()
 
     def on_test_batch_end(
@@ -201,12 +203,12 @@ class PerRFUOutcomeCallback(Callback):
             )
 
     def on_test_epoch_end(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
-        """Write compact RFU outcome CSV at the end of testing."""
+        """Write RFU outcome NPZ at the end of testing."""
         del pl_module
         outcomes = self.metric.compute()
 
         if getattr(trainer, "is_global_zero", True):
-            write_rfu_outcome_csv(self._output_path(trainer), outcomes)
+            write_rfu_outcome_npz(self._output_path(trainer), outcomes)
 
         self.metric.reset()
 

--- a/src/dnanet/evaluation/callbacks.py
+++ b/src/dnanet/evaluation/callbacks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from pathlib import Path
 from collections.abc import Mapping, Sequence
 
 import numpy as np
@@ -10,6 +11,7 @@ from lightning import Callback
 
 from dnanet.core.annotation import AlleleAnnotation
 from dnanet.evaluation.metrics.allele import AlleleRecall, AlleleF1Score, AllelePrecision
+from dnanet.evaluation.metrics.per_RFU import PerRFUOutcomeMetric, write_rfu_outcome_csv
 
 
 if TYPE_CHECKING:
@@ -138,3 +140,100 @@ class AlleleMetricsCallback(Callback):
         self.precision.reset()
         self.recall.reset()
         self.f1.reset()
+
+
+class PerRFUOutcomeCallback(Callback):
+    """Collect TP/FP/FN RFU values during Lightning test runs."""
+
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        filename: str = "per_rfu_outcomes.csv",
+        metric: PerRFUOutcomeMetric | None = None,
+    ) -> None:
+        """Initialize the RFU outcome callback."""
+        self.metric = metric or PerRFUOutcomeMetric(threshold=threshold)
+        self.filename = filename
+
+    def on_test_epoch_start(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
+        """Reset RFU outcome state before a test epoch starts."""
+        del trainer, pl_module
+        self.metric.reset()
+
+    def on_test_batch_end(
+        self,
+        trainer: L.Trainer,
+        pl_module: L.LightningModule,
+        outputs: Mapping[str, Tensor] | None,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        """Update RFU outcome state from batch predictions, targets, and metadata."""
+        del trainer, pl_module, batch_idx, dataloader_idx
+
+        if outputs is None or "preds" not in outputs:
+            raise ValueError(
+                "PerRFUOutcomeCallback requires test_step to return a mapping "
+                "with a 'preds' tensor."
+            )
+
+        metadata = AlleleMetricsCallback._metadata_from_batch(batch)
+        targets = self._targets_from_batch(batch)
+        preds = outputs["preds"].detach().cpu().numpy()
+        targets = targets.detach().cpu().numpy()
+
+        if len(preds) != len(metadata) or len(targets) != len(metadata):
+            raise ValueError(
+                "Number of predictions, targets, and metadata entries must match, got "
+                f"{len(preds)}, {len(targets)}, and {len(metadata)}."
+            )
+
+        for pred, target, sample_metadata in zip(preds, targets, metadata, strict=True):
+            signal_image = sample_metadata.get("signal_image")
+            if signal_image is None:
+                raise ValueError("Missing signal_image in sample metadata.")
+
+            self.metric.update(
+                preds=self._as_2d_array(pred),
+                targets=self._as_2d_array(target),
+                rfu_values=self._as_2d_array(signal_image),
+            )
+
+    def on_test_epoch_end(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
+        """Write compact RFU outcome CSV at the end of testing."""
+        del pl_module
+        outcomes = self.metric.compute()
+
+        if getattr(trainer, "is_global_zero", True):
+            write_rfu_outcome_csv(self._output_path(trainer), outcomes)
+
+        self.metric.reset()
+
+    @staticmethod
+    def _targets_from_batch(batch: Any) -> Tensor:
+        if not isinstance(batch, (tuple, list)) or len(batch) != 3:
+            raise ValueError(
+                "PerRFUOutcomeCallback requires batches from a metadata transformer "
+                "with shape (inputs, targets, metadata)."
+            )
+
+        targets = batch[1]
+        if not hasattr(targets, "detach"):
+            raise TypeError("Expected batch targets to be a tensor.")
+        return targets
+
+    @staticmethod
+    def _as_2d_array(array: Any) -> np.ndarray:
+        result = np.asarray(array)
+        if result.ndim == 3 and result.shape[-1] == 1:
+            result = result[..., 0]
+        return result
+
+    def _output_path(self, trainer: L.Trainer) -> Path:
+        path = Path(self.filename)
+        if path.is_absolute():
+            return path
+
+        root_dir = Path(getattr(trainer, "default_root_dir", ".") or ".")
+        return root_dir / path

--- a/src/dnanet/evaluation/callbacks.py
+++ b/src/dnanet/evaluation/callbacks.py
@@ -12,7 +12,7 @@ from lightning import Callback
 
 from dnanet.core.annotation import AlleleAnnotation
 from dnanet.evaluation.metrics.allele import AlleleRecall, AlleleF1Score, AllelePrecision
-from dnanet.evaluation.metrics.per_RFU import PerRFUOutcomeMetric, write_rfu_outcome_npz
+from dnanet.evaluation.metrics.per_RFU import PerRFUOutcomeMetric, write_rfu_outcome_file
 
 
 if TYPE_CHECKING:
@@ -159,7 +159,7 @@ class PerRFUOutcomeCallback(Callback):
     def on_test_epoch_start(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
         """Reset RFU outcome state before a test epoch starts."""
         del trainer, pl_module
-        logger.warning("Per-RFU outcome logging may create large NPZ files.")
+        logger.warning("Per-RFU outcome logging may create large output files.")
         self.metric.reset()
 
     def on_test_batch_end(
@@ -208,7 +208,7 @@ class PerRFUOutcomeCallback(Callback):
         outcomes = self.metric.compute()
 
         if getattr(trainer, "is_global_zero", True):
-            write_rfu_outcome_npz(self._output_path(trainer), outcomes)
+            write_rfu_outcome_file(self._output_path(trainer), outcomes)
 
         self.metric.reset()
 

--- a/src/dnanet/evaluation/metrics/__init__.py
+++ b/src/dnanet/evaluation/metrics/__init__.py
@@ -9,6 +9,13 @@ from dnanet.evaluation.metrics.allele import (
     AlleleF1Score,
     AllelePrecision,
 )
+from dnanet.evaluation.metrics.per_RFU import (
+    PerRFUOutcomeMetric,
+    compute_binned_f1,
+    load_rfu_outcome_csv,
+    write_rfu_outcome_csv,
+    compute_binned_f1_from_csv,
+)
 
 
 __all__ = [
@@ -16,4 +23,9 @@ __all__ = [
     "AllelePrecision",
     "AlleleRecall",
     "AlleleF1Score",
+    "PerRFUOutcomeMetric",
+    "write_rfu_outcome_csv",
+    "load_rfu_outcome_csv",
+    "compute_binned_f1",
+    "compute_binned_f1_from_csv",
 ]

--- a/src/dnanet/evaluation/metrics/__init__.py
+++ b/src/dnanet/evaluation/metrics/__init__.py
@@ -12,9 +12,9 @@ from dnanet.evaluation.metrics.allele import (
 from dnanet.evaluation.metrics.per_RFU import (
     PerRFUOutcomeMetric,
     compute_binned_f1,
-    load_rfu_outcome_csv,
-    write_rfu_outcome_csv,
-    compute_binned_f1_from_csv,
+    load_rfu_outcome_npz,
+    write_rfu_outcome_npz,
+    compute_binned_f1_from_npz,
 )
 
 
@@ -24,8 +24,8 @@ __all__ = [
     "AlleleRecall",
     "AlleleF1Score",
     "PerRFUOutcomeMetric",
-    "write_rfu_outcome_csv",
-    "load_rfu_outcome_csv",
+    "write_rfu_outcome_npz",
+    "load_rfu_outcome_npz",
     "compute_binned_f1",
-    "compute_binned_f1_from_csv",
+    "compute_binned_f1_from_npz",
 ]

--- a/src/dnanet/evaluation/metrics/__init__.py
+++ b/src/dnanet/evaluation/metrics/__init__.py
@@ -12,8 +12,12 @@ from dnanet.evaluation.metrics.allele import (
 from dnanet.evaluation.metrics.per_RFU import (
     PerRFUOutcomeMetric,
     compute_binned_f1,
+    load_rfu_outcome_csv,
     load_rfu_outcome_npz,
+    write_rfu_outcome_csv,
     write_rfu_outcome_npz,
+    write_rfu_outcome_file,
+    compute_binned_f1_from_csv,
     compute_binned_f1_from_npz,
 )
 
@@ -24,8 +28,12 @@ __all__ = [
     "AlleleRecall",
     "AlleleF1Score",
     "PerRFUOutcomeMetric",
+    "write_rfu_outcome_file",
     "write_rfu_outcome_npz",
+    "write_rfu_outcome_csv",
     "load_rfu_outcome_npz",
+    "load_rfu_outcome_csv",
     "compute_binned_f1",
     "compute_binned_f1_from_npz",
+    "compute_binned_f1_from_csv",
 ]

--- a/src/dnanet/evaluation/metrics/per_RFU.py
+++ b/src/dnanet/evaluation/metrics/per_RFU.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 from typing import TYPE_CHECKING
 from pathlib import Path
 
@@ -72,9 +73,22 @@ class PerRFUOutcomeMetric(Metric):
             "fn_rfus": _cat_tensors(self.fn_rfus, device=self.device),
         }
 
-    def write_npz(self, path: str | Path) -> Path:
-        """Write accumulated outcomes as a compressed NPZ archive."""
-        return write_rfu_outcome_npz(path, self.compute())
+
+def write_rfu_outcome_file(
+    path: str | Path,
+    outcomes: Mapping[str, Tensor | np.ndarray | Sequence[float] | Sequence[Tensor]],
+) -> Path:
+    """Write RFU outcomes based on the filename extension."""
+    output_path = Path(path)
+    suffix = output_path.suffix.lower()
+    if suffix == ".npz":
+        return write_rfu_outcome_npz(output_path, outcomes)
+    if suffix == ".csv":
+        return write_rfu_outcome_csv(output_path, outcomes)
+    raise ValueError(
+        "RFU outcome filename must end with '.npz' or '.csv', got "
+        f"{output_path.name!r}."
+    )
 
 
 def write_rfu_outcome_npz(
@@ -97,6 +111,24 @@ def write_rfu_outcome_npz(
     return output_path
 
 
+def write_rfu_outcome_csv(
+    path: str | Path,
+    outcomes: Mapping[str, Tensor | np.ndarray | Sequence[float] | Sequence[Tensor]],
+) -> Path:
+    """Write RFU outcomes as compact ``outcome,rfu`` CSV rows."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(("outcome", "rfu"))
+        for outcome in RFU_OUTCOMES:
+            for rfu in _outcome_array(outcomes, outcome):
+                writer.writerow((outcome, f"{rfu:g}"))
+
+    return output_path
+
+
 def load_rfu_outcome_npz(path: str | Path) -> dict[str, np.ndarray]:
     """Load an RFU outcome NPZ written by :func:`write_rfu_outcome_npz`."""
     with np.load(Path(path)) as data:
@@ -108,6 +140,24 @@ def load_rfu_outcome_npz(path: str | Path) -> dict[str, np.ndarray]:
             f"{outcome}_rfus": np.asarray(data[f"{outcome}_rfus"], dtype=float).reshape(-1)
             for outcome in RFU_OUTCOMES
         }
+
+
+def load_rfu_outcome_csv(path: str | Path) -> dict[str, np.ndarray]:
+    """Load an RFU outcome CSV written by :func:`write_rfu_outcome_csv`."""
+    values: dict[str, list[float]] = {f"{outcome}_rfus": [] for outcome in RFU_OUTCOMES}
+
+    with Path(path).open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            outcome = row["outcome"]
+            if outcome not in RFU_OUTCOMES:
+                raise ValueError(f"Unknown RFU outcome {outcome!r}.")
+            values[f"{outcome}_rfus"].append(float(row["rfu"]))
+
+    return {
+        key: np.asarray(outcome_values, dtype=float)
+        for key, outcome_values in values.items()
+    }
 
 
 def compute_binned_f1(
@@ -151,6 +201,14 @@ def compute_binned_f1_from_npz(
 ) -> list[dict[str, float | int]]:
     """Load an RFU outcome NPZ and compute binned F1 rows."""
     return compute_binned_f1(load_rfu_outcome_npz(path), bin_edges)
+
+
+def compute_binned_f1_from_csv(
+    path: str | Path,
+    bin_edges: Sequence[float],
+) -> list[dict[str, float | int]]:
+    """Load an RFU outcome CSV and compute binned F1 rows."""
+    return compute_binned_f1(load_rfu_outcome_csv(path), bin_edges)
 
 
 def _to_tensor(value: Tensor, *, device: torch.device) -> Tensor:

--- a/src/dnanet/evaluation/metrics/per_RFU.py
+++ b/src/dnanet/evaluation/metrics/per_RFU.py
@@ -1,0 +1,196 @@
+"""RFU outcome collection for later F1-by-RFU analysis."""
+
+from __future__ import annotations
+
+import csv
+from typing import TYPE_CHECKING
+from pathlib import Path
+
+import numpy as np
+import torch
+from torch import Tensor
+from torchmetrics import Metric
+
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+
+RFU_OUTCOMES: tuple[str, ...] = ("tp", "fp", "fn")
+
+
+class PerRFUOutcomeMetric(Metric):
+    """Collect RFU values for true positives, false positives, and false negatives.
+
+    The metric intentionally does not bin RFU values during evaluation. It stores
+    only the RFU values needed to compute precision, recall, and F1 later with
+    arbitrary bin edges.
+    """
+
+    full_state_update = False
+    is_differentiable = False
+    higher_is_better = None
+
+    def __init__(self, threshold: float = 0.5, **kwargs) -> None:
+        """Initialize the accumulator with a prediction threshold."""
+        super().__init__(**kwargs)
+        self.threshold = threshold
+        self.add_state("tp_rfus", default=[], dist_reduce_fx="cat")
+        self.add_state("fp_rfus", default=[], dist_reduce_fx="cat")
+        self.add_state("fn_rfus", default=[], dist_reduce_fx="cat")
+
+    def update(self, preds: Tensor, targets: Tensor, rfu_values: Tensor) -> None:
+        """Collect RFU values for TP, FP, and FN scanpoints."""
+        preds = _to_tensor(preds, device=self.device)
+        targets = _to_tensor(targets, device=self.device)
+        rfu_values = _to_tensor(rfu_values, device=self.device)
+
+        if preds.shape != targets.shape or preds.shape != rfu_values.shape:
+            raise ValueError(
+                "preds, targets, and rfu_values must have identical shapes, got "
+                f"{tuple(preds.shape)}, {tuple(targets.shape)}, and "
+                f"{tuple(rfu_values.shape)}."
+            )
+
+        pred_mask = preds >= self.threshold
+        target_mask = targets.bool()
+        valid_rfu_mask = torch.isfinite(rfu_values)
+
+        rfu_values = rfu_values.float()
+        self.tp_rfus.append(rfu_values[target_mask & pred_mask & valid_rfu_mask].detach())
+        self.fp_rfus.append(rfu_values[(~target_mask) & pred_mask & valid_rfu_mask].detach())
+        self.fn_rfus.append(rfu_values[target_mask & (~pred_mask) & valid_rfu_mask].detach())
+
+    def compute(self) -> dict[str, Tensor]:
+        """Return accumulated RFU values grouped by outcome."""
+        return self.compute_outcomes()
+
+    def compute_outcomes(self) -> dict[str, Tensor]:
+        """Return accumulated RFU values as stable one-dimensional tensors."""
+        return {
+            "tp_rfus": _cat_tensors(self.tp_rfus, device=self.device),
+            "fp_rfus": _cat_tensors(self.fp_rfus, device=self.device),
+            "fn_rfus": _cat_tensors(self.fn_rfus, device=self.device),
+        }
+
+    def write_csv(self, path: str | Path) -> Path:
+        """Write accumulated outcomes as a compact two-column CSV."""
+        return write_rfu_outcome_csv(path, self.compute())
+
+
+
+
+def write_rfu_outcome_csv(
+    path: str | Path,
+    outcomes: Mapping[str, Tensor | np.ndarray | Sequence[float] | Sequence[Tensor]],
+) -> Path:
+    """Write RFU outcomes as ``outcome,rfu`` rows."""
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(("outcome", "rfu"))
+        for outcome in RFU_OUTCOMES:
+            for rfu in _outcome_array(outcomes, outcome):
+                writer.writerow((outcome, f"{rfu:g}"))
+
+    return output_path
+
+
+def load_rfu_outcome_csv(path: str | Path) -> dict[str, np.ndarray]:
+    """Load an RFU outcome CSV written by :func:`write_rfu_outcome_csv`."""
+    values: dict[str, list[float]] = {f"{outcome}_rfus": [] for outcome in RFU_OUTCOMES}
+
+    with Path(path).open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            outcome = row["outcome"]
+            if outcome not in RFU_OUTCOMES:
+                raise ValueError(f"Unknown RFU outcome {outcome!r}.")
+            values[f"{outcome}_rfus"].append(float(row["rfu"]))
+
+    return {
+        key: np.asarray(outcome_values, dtype=float)
+        for key, outcome_values in values.items()
+    }
+
+
+def compute_binned_f1(
+    outcomes: Mapping[str, Tensor | np.ndarray | Sequence[float] | Sequence[Tensor]],
+    bin_edges: Sequence[float],
+) -> list[dict[str, float | int]]:
+    """Compute precision, recall, and F1 for arbitrary RFU bins."""
+    edges = np.asarray(bin_edges, dtype=float)
+    if edges.ndim != 1 or len(edges) < 2:
+        raise ValueError("bin_edges must be a one-dimensional sequence with at least two values.")
+    if not np.all(np.diff(edges) > 0):
+        raise ValueError("bin_edges must be strictly increasing.")
+
+    tp = np.histogram(_outcome_array(outcomes, "tp"), bins=edges)[0]
+    fp = np.histogram(_outcome_array(outcomes, "fp"), bins=edges)[0]
+    fn = np.histogram(_outcome_array(outcomes, "fn"), bins=edges)[0]
+
+    precision = _safe_divide_np(tp, tp + fp)
+    recall = _safe_divide_np(tp, tp + fn)
+    f1 = _safe_divide_np(2 * precision * recall, precision + recall)
+
+    return [
+        {
+            "bin_left": float(edges[idx]),
+            "bin_right": float(edges[idx + 1]),
+            "tp": int(tp[idx]),
+            "fp": int(fp[idx]),
+            "fn": int(fn[idx]),
+            "support": int(tp[idx] + fn[idx]),
+            "precision": float(precision[idx]),
+            "recall": float(recall[idx]),
+            "f1": float(f1[idx]),
+        }
+        for idx in range(len(edges) - 1)
+    ]
+
+
+def compute_binned_f1_from_csv(
+    path: str | Path,
+    bin_edges: Sequence[float],
+) -> list[dict[str, float | int]]:
+    """Load an RFU outcome CSV and compute binned F1 rows."""
+    return compute_binned_f1(load_rfu_outcome_csv(path), bin_edges)
+
+
+def _to_tensor(value: Tensor, *, device: torch.device) -> Tensor:
+    if isinstance(value, Tensor):
+        return value.to(device)
+    return torch.as_tensor(value, device=device)
+
+
+def _cat_tensors(values: Sequence[Tensor], *, device: torch.device) -> Tensor:
+    if not values:
+        return torch.empty(0, dtype=torch.float32, device=device)
+    return torch.cat([value.reshape(-1).float().to(device) for value in values])
+
+
+def _outcome_array(
+    outcomes: Mapping[str, Tensor | np.ndarray | Sequence[float] | Sequence[Tensor]],
+    outcome: str,
+) -> np.ndarray:
+    key = f"{outcome}_rfus"
+    values = outcomes.get(key, outcomes.get(outcome))
+    if values is None:
+        return np.empty(0, dtype=float)
+    if isinstance(values, Tensor):
+        return values.detach().cpu().numpy().astype(float, copy=False).reshape(-1)
+    if isinstance(values, np.ndarray):
+        return values.astype(float, copy=False).reshape(-1)
+    if len(values) == 0:
+        return np.empty(0, dtype=float)
+    if all(isinstance(value, Tensor) for value in values):
+        return _cat_tensors(values, device=torch.device("cpu")).numpy()
+    return np.asarray(values, dtype=float).reshape(-1)
+
+
+def _safe_divide_np(numerator: np.ndarray, denominator: np.ndarray) -> np.ndarray:
+    result = np.zeros_like(numerator, dtype=float)
+    np.divide(numerator, denominator, out=result, where=denominator != 0)
+    return result

--- a/src/dnanet/evaluation/metrics/per_RFU.py
+++ b/src/dnanet/evaluation/metrics/per_RFU.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import csv
 from typing import TYPE_CHECKING
 from pathlib import Path
 
@@ -73,47 +72,42 @@ class PerRFUOutcomeMetric(Metric):
             "fn_rfus": _cat_tensors(self.fn_rfus, device=self.device),
         }
 
-    def write_csv(self, path: str | Path) -> Path:
-        """Write accumulated outcomes as a compact two-column CSV."""
-        return write_rfu_outcome_csv(path, self.compute())
+    def write_npz(self, path: str | Path) -> Path:
+        """Write accumulated outcomes as a compressed NPZ archive."""
+        return write_rfu_outcome_npz(path, self.compute())
 
 
-
-
-def write_rfu_outcome_csv(
+def write_rfu_outcome_npz(
     path: str | Path,
     outcomes: Mapping[str, Tensor | np.ndarray | Sequence[float] | Sequence[Tensor]],
 ) -> Path:
-    """Write RFU outcomes as ``outcome,rfu`` rows."""
+    """Write RFU outcomes as a compressed NPZ archive."""
     output_path = Path(path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with output_path.open("w", newline="", encoding="utf-8") as handle:
-        writer = csv.writer(handle)
-        writer.writerow(("outcome", "rfu"))
-        for outcome in RFU_OUTCOMES:
-            for rfu in _outcome_array(outcomes, outcome):
-                writer.writerow((outcome, f"{rfu:g}"))
+    with output_path.open("wb") as handle:
+        np.savez_compressed(
+            handle,
+            **{
+                f"{outcome}_rfus": _outcome_array(outcomes, outcome)
+                for outcome in RFU_OUTCOMES
+            },
+        )
 
     return output_path
 
 
-def load_rfu_outcome_csv(path: str | Path) -> dict[str, np.ndarray]:
-    """Load an RFU outcome CSV written by :func:`write_rfu_outcome_csv`."""
-    values: dict[str, list[float]] = {f"{outcome}_rfus": [] for outcome in RFU_OUTCOMES}
+def load_rfu_outcome_npz(path: str | Path) -> dict[str, np.ndarray]:
+    """Load an RFU outcome NPZ written by :func:`write_rfu_outcome_npz`."""
+    with np.load(Path(path)) as data:
+        missing = [f"{outcome}_rfus" for outcome in RFU_OUTCOMES if f"{outcome}_rfus" not in data]
+        if missing:
+            raise ValueError(f"Missing RFU outcome array(s): {', '.join(missing)}.")
 
-    with Path(path).open(newline="", encoding="utf-8") as handle:
-        reader = csv.DictReader(handle)
-        for row in reader:
-            outcome = row["outcome"]
-            if outcome not in RFU_OUTCOMES:
-                raise ValueError(f"Unknown RFU outcome {outcome!r}.")
-            values[f"{outcome}_rfus"].append(float(row["rfu"]))
-
-    return {
-        key: np.asarray(outcome_values, dtype=float)
-        for key, outcome_values in values.items()
-    }
+        return {
+            f"{outcome}_rfus": np.asarray(data[f"{outcome}_rfus"], dtype=float).reshape(-1)
+            for outcome in RFU_OUTCOMES
+        }
 
 
 def compute_binned_f1(
@@ -151,12 +145,12 @@ def compute_binned_f1(
     ]
 
 
-def compute_binned_f1_from_csv(
+def compute_binned_f1_from_npz(
     path: str | Path,
     bin_edges: Sequence[float],
 ) -> list[dict[str, float | int]]:
-    """Load an RFU outcome CSV and compute binned F1 rows."""
-    return compute_binned_f1(load_rfu_outcome_csv(path), bin_edges)
+    """Load an RFU outcome NPZ and compute binned F1 rows."""
+    return compute_binned_f1(load_rfu_outcome_npz(path), bin_edges)
 
 
 def _to_tensor(value: Tensor, *, device: torch.device) -> Tensor:

--- a/tests/evaluation/test_per_rfu_callback.py
+++ b/tests/evaluation/test_per_rfu_callback.py
@@ -1,9 +1,5 @@
 """Tests for the RFU outcome Lightning callback."""
 
-from __future__ import annotations
-
-import csv
-
 import numpy as np
 import torch
 import pytest
@@ -21,8 +17,8 @@ class FakeModule:
     pass
 
 
-def test_per_rfu_callback_writes_compact_outcome_csv(tmp_path):
-    callback = PerRFUOutcomeCallback(threshold=0.5, filename="per_rfu_outcomes.csv")
+def test_per_rfu_callback_writes_outcome_npz(tmp_path):
+    callback = PerRFUOutcomeCallback(threshold=0.5, filename="per_rfu_outcomes.npz")
     trainer = FakeTrainer(tmp_path)
     module = FakeModule()
 
@@ -40,14 +36,10 @@ def test_per_rfu_callback_writes_compact_outcome_csv(tmp_path):
     callback.on_test_batch_end(trainer, module, outputs=outputs, batch=batch, batch_idx=0)
     callback.on_test_epoch_end(trainer, module)
 
-    with (tmp_path / "per_rfu_outcomes.csv").open(newline="", encoding="utf-8") as handle:
-        rows = list(csv.DictReader(handle))
-
-    assert rows == [
-        {"outcome": "tp", "rfu": "10"},
-        {"outcome": "fp", "rfu": "30"},
-        {"outcome": "fn", "rfu": "20"},
-    ]
+    with np.load(tmp_path / "per_rfu_outcomes.npz") as data:
+        assert data["tp_rfus"].tolist() == pytest.approx([10.0])
+        assert data["fp_rfus"].tolist() == pytest.approx([30.0])
+        assert data["fn_rfus"].tolist() == pytest.approx([20.0])
 
 
 def test_per_rfu_callback_accepts_trailing_singleton_channel(tmp_path):

--- a/tests/evaluation/test_per_rfu_callback.py
+++ b/tests/evaluation/test_per_rfu_callback.py
@@ -1,5 +1,7 @@
 """Tests for the RFU outcome Lightning callback."""
 
+import csv
+
 import numpy as np
 import torch
 import pytest
@@ -40,6 +42,35 @@ def test_per_rfu_callback_writes_outcome_npz(tmp_path):
         assert data["tp_rfus"].tolist() == pytest.approx([10.0])
         assert data["fp_rfus"].tolist() == pytest.approx([30.0])
         assert data["fn_rfus"].tolist() == pytest.approx([20.0])
+
+
+def test_per_rfu_callback_writes_outcome_csv_when_configured(tmp_path):
+    callback = PerRFUOutcomeCallback(threshold=0.5, filename="per_rfu_outcomes.csv")
+    trainer = FakeTrainer(tmp_path)
+    module = FakeModule()
+
+    batch = (
+        torch.zeros((1, 1, 4), dtype=torch.float32),
+        torch.tensor([[[1, 1, 0, 0]]], dtype=torch.float32),
+        [{
+            "path": "sample.hid",
+            "signal_image": np.array([[10.0, 20.0, 30.0, 40.0]], dtype=np.float32),
+        }],
+    )
+    outputs = {"preds": torch.tensor([[[0.6, 0.4, 0.7, 0.2]]], dtype=torch.float32)}
+
+    callback.on_test_epoch_start(trainer, module)
+    callback.on_test_batch_end(trainer, module, outputs=outputs, batch=batch, batch_idx=0)
+    callback.on_test_epoch_end(trainer, module)
+
+    with (tmp_path / "per_rfu_outcomes.csv").open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows == [
+        {"outcome": "tp", "rfu": "10"},
+        {"outcome": "fp", "rfu": "30"},
+        {"outcome": "fn", "rfu": "20"},
+    ]
 
 
 def test_per_rfu_callback_accepts_trailing_singleton_channel(tmp_path):

--- a/tests/evaluation/test_per_rfu_callback.py
+++ b/tests/evaluation/test_per_rfu_callback.py
@@ -1,0 +1,90 @@
+"""Tests for the RFU outcome Lightning callback."""
+
+from __future__ import annotations
+
+import csv
+
+import numpy as np
+import torch
+import pytest
+
+from dnanet.evaluation.callbacks import PerRFUOutcomeCallback
+
+
+class FakeTrainer:
+    def __init__(self, default_root_dir) -> None:
+        self.default_root_dir = str(default_root_dir)
+        self.is_global_zero = True
+
+
+class FakeModule:
+    pass
+
+
+def test_per_rfu_callback_writes_compact_outcome_csv(tmp_path):
+    callback = PerRFUOutcomeCallback(threshold=0.5, filename="per_rfu_outcomes.csv")
+    trainer = FakeTrainer(tmp_path)
+    module = FakeModule()
+
+    batch = (
+        torch.zeros((1, 1, 4), dtype=torch.float32),
+        torch.tensor([[[1, 1, 0, 0]]], dtype=torch.float32),
+        [{
+            "path": "sample.hid",
+            "signal_image": np.array([[10.0, 20.0, 30.0, 40.0]], dtype=np.float32),
+        }],
+    )
+    outputs = {"preds": torch.tensor([[[0.6, 0.4, 0.7, 0.2]]], dtype=torch.float32)}
+
+    callback.on_test_epoch_start(trainer, module)
+    callback.on_test_batch_end(trainer, module, outputs=outputs, batch=batch, batch_idx=0)
+    callback.on_test_epoch_end(trainer, module)
+
+    with (tmp_path / "per_rfu_outcomes.csv").open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows == [
+        {"outcome": "tp", "rfu": "10"},
+        {"outcome": "fp", "rfu": "30"},
+        {"outcome": "fn", "rfu": "20"},
+    ]
+
+
+def test_per_rfu_callback_accepts_trailing_singleton_channel(tmp_path):
+    callback = PerRFUOutcomeCallback(threshold=0.5)
+    trainer = FakeTrainer(tmp_path)
+    module = FakeModule()
+
+    batch = (
+        torch.zeros((1, 1, 3, 1), dtype=torch.float32),
+        torch.tensor([[[[1], [0], [1]]]], dtype=torch.float32),
+        [{
+            "signal_image": np.array([[[100.0], [200.0], [300.0]]], dtype=np.float32),
+        }],
+    )
+    outputs = {"preds": torch.tensor([[[[0.9], [0.8], [0.1]]]], dtype=torch.float32)}
+
+    callback.on_test_epoch_start(trainer, module)
+    callback.on_test_batch_end(trainer, module, outputs=outputs, batch=batch, batch_idx=0)
+    outcomes = callback.metric.compute_outcomes()
+
+    assert outcomes["tp_rfus"].tolist() == pytest.approx([100.0])
+    assert outcomes["fp_rfus"].tolist() == pytest.approx([200.0])
+    assert outcomes["fn_rfus"].tolist() == pytest.approx([300.0])
+
+
+def test_per_rfu_callback_requires_signal_image_metadata():
+    callback = PerRFUOutcomeCallback()
+
+    with pytest.raises(ValueError, match="signal_image"):
+        callback.on_test_batch_end(
+            FakeTrainer("."),
+            FakeModule(),
+            outputs={"preds": torch.zeros((1, 1, 4), dtype=torch.float32)},
+            batch=(
+                torch.zeros((1, 1, 4), dtype=torch.float32),
+                torch.zeros((1, 1, 4), dtype=torch.float32),
+                [{"path": "sample.hid"}],
+            ),
+            batch_idx=0,
+        )

--- a/tests/evaluation/test_per_rfu_metric.py
+++ b/tests/evaluation/test_per_rfu_metric.py
@@ -1,0 +1,109 @@
+"""Tests for RFU outcome collection and later F1 binning."""
+
+from __future__ import annotations
+
+import csv
+
+import torch
+import pytest
+
+from dnanet.evaluation.metrics.per_RFU import (
+    PerRFUOutcomeMetric,
+    compute_binned_f1,
+    load_rfu_outcome_csv,
+    write_rfu_outcome_csv,
+    compute_binned_f1_from_csv,
+)
+
+
+def test_per_rfu_metric_collects_only_tp_fp_fn_rfus():
+    metric = PerRFUOutcomeMetric(threshold=0.5)
+
+    preds = torch.tensor([[0.6, 0.4, 0.7, 0.2]])
+    targets = torch.tensor([[1, 1, 0, 0]])
+    rfu_values = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+
+    metric.update(preds, targets, rfu_values)
+    outcomes = metric.compute_outcomes()
+
+    assert outcomes["tp_rfus"].tolist() == pytest.approx([10.0])
+    assert outcomes["fp_rfus"].tolist() == pytest.approx([30.0])
+    assert outcomes["fn_rfus"].tolist() == pytest.approx([20.0])
+
+
+def test_per_rfu_metric_uses_configured_threshold():
+    metric = PerRFUOutcomeMetric(threshold=0.75)
+
+    preds = torch.tensor([[0.7, 0.8]])
+    targets = torch.tensor([[1, 1]])
+    rfu_values = torch.tensor([[100.0, 200.0]])
+
+    metric.update(preds, targets, rfu_values)
+    outcomes = metric.compute_outcomes()
+
+    assert outcomes["tp_rfus"].tolist() == pytest.approx([200.0])
+    assert outcomes["fn_rfus"].tolist() == pytest.approx([100.0])
+
+
+def test_rfu_outcome_csv_round_trip(tmp_path):
+    path = tmp_path / "per_rfu_outcomes.csv"
+    outcomes = {
+        "tp_rfus": torch.tensor([10.0, 11.0]),
+        "fp_rfus": torch.tensor([20.0]),
+        "fn_rfus": torch.tensor([30.0]),
+    }
+
+    write_rfu_outcome_csv(path, outcomes)
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows == [
+        {"outcome": "tp", "rfu": "10"},
+        {"outcome": "tp", "rfu": "11"},
+        {"outcome": "fp", "rfu": "20"},
+        {"outcome": "fn", "rfu": "30"},
+    ]
+
+    loaded = load_rfu_outcome_csv(path)
+    assert loaded["tp_rfus"].tolist() == pytest.approx([10.0, 11.0])
+    assert loaded["fp_rfus"].tolist() == pytest.approx([20.0])
+    assert loaded["fn_rfus"].tolist() == pytest.approx([30.0])
+
+
+def test_compute_binned_f1_from_saved_outcomes(tmp_path):
+    path = tmp_path / "per_rfu_outcomes.csv"
+    write_rfu_outcome_csv(
+        path,
+        {
+            "tp_rfus": [10.0, 110.0],
+            "fp_rfus": [20.0],
+            "fn_rfus": [120.0],
+        },
+    )
+
+    rows = compute_binned_f1_from_csv(path, [0.0, 100.0, 200.0])
+
+    assert rows == compute_binned_f1(load_rfu_outcome_csv(path), [0.0, 100.0, 200.0])
+    assert rows[0] == {
+        "bin_left": 0.0,
+        "bin_right": 100.0,
+        "tp": 1,
+        "fp": 1,
+        "fn": 0,
+        "support": 1,
+        "precision": pytest.approx(0.5),
+        "recall": pytest.approx(1.0),
+        "f1": pytest.approx(2 / 3),
+    }
+    assert rows[1] == {
+        "bin_left": 100.0,
+        "bin_right": 200.0,
+        "tp": 1,
+        "fp": 0,
+        "fn": 1,
+        "support": 2,
+        "precision": pytest.approx(1.0),
+        "recall": pytest.approx(0.5),
+        "f1": pytest.approx(2 / 3),
+    }

--- a/tests/evaluation/test_per_rfu_metric.py
+++ b/tests/evaluation/test_per_rfu_metric.py
@@ -1,18 +1,15 @@
 """Tests for RFU outcome collection and later F1 binning."""
 
-from __future__ import annotations
-
-import csv
-
+import numpy as np
 import torch
 import pytest
 
 from dnanet.evaluation.metrics.per_RFU import (
     PerRFUOutcomeMetric,
     compute_binned_f1,
-    load_rfu_outcome_csv,
-    write_rfu_outcome_csv,
-    compute_binned_f1_from_csv,
+    load_rfu_outcome_npz,
+    write_rfu_outcome_npz,
+    compute_binned_f1_from_npz,
 )
 
 
@@ -45,35 +42,30 @@ def test_per_rfu_metric_uses_configured_threshold():
     assert outcomes["fn_rfus"].tolist() == pytest.approx([100.0])
 
 
-def test_rfu_outcome_csv_round_trip(tmp_path):
-    path = tmp_path / "per_rfu_outcomes.csv"
+def test_rfu_outcome_npz_round_trip(tmp_path):
+    path = tmp_path / "per_rfu_outcomes.npz"
     outcomes = {
         "tp_rfus": torch.tensor([10.0, 11.0]),
         "fp_rfus": torch.tensor([20.0]),
         "fn_rfus": torch.tensor([30.0]),
     }
 
-    write_rfu_outcome_csv(path, outcomes)
+    write_rfu_outcome_npz(path, outcomes)
 
-    with path.open(newline="", encoding="utf-8") as handle:
-        rows = list(csv.DictReader(handle))
+    with np.load(path) as data:
+        assert data["tp_rfus"].tolist() == pytest.approx([10.0, 11.0])
+        assert data["fp_rfus"].tolist() == pytest.approx([20.0])
+        assert data["fn_rfus"].tolist() == pytest.approx([30.0])
 
-    assert rows == [
-        {"outcome": "tp", "rfu": "10"},
-        {"outcome": "tp", "rfu": "11"},
-        {"outcome": "fp", "rfu": "20"},
-        {"outcome": "fn", "rfu": "30"},
-    ]
-
-    loaded = load_rfu_outcome_csv(path)
+    loaded = load_rfu_outcome_npz(path)
     assert loaded["tp_rfus"].tolist() == pytest.approx([10.0, 11.0])
     assert loaded["fp_rfus"].tolist() == pytest.approx([20.0])
     assert loaded["fn_rfus"].tolist() == pytest.approx([30.0])
 
 
 def test_compute_binned_f1_from_saved_outcomes(tmp_path):
-    path = tmp_path / "per_rfu_outcomes.csv"
-    write_rfu_outcome_csv(
+    path = tmp_path / "per_rfu_outcomes.npz"
+    write_rfu_outcome_npz(
         path,
         {
             "tp_rfus": [10.0, 110.0],
@@ -82,9 +74,9 @@ def test_compute_binned_f1_from_saved_outcomes(tmp_path):
         },
     )
 
-    rows = compute_binned_f1_from_csv(path, [0.0, 100.0, 200.0])
+    rows = compute_binned_f1_from_npz(path, [0.0, 100.0, 200.0])
 
-    assert rows == compute_binned_f1(load_rfu_outcome_csv(path), [0.0, 100.0, 200.0])
+    assert rows == compute_binned_f1(load_rfu_outcome_npz(path), [0.0, 100.0, 200.0])
     assert rows[0] == {
         "bin_left": 0.0,
         "bin_right": 100.0,

--- a/tests/evaluation/test_per_rfu_metric.py
+++ b/tests/evaluation/test_per_rfu_metric.py
@@ -1,5 +1,7 @@
 """Tests for RFU outcome collection and later F1 binning."""
 
+import csv
+
 import numpy as np
 import torch
 import pytest
@@ -7,8 +9,12 @@ import pytest
 from dnanet.evaluation.metrics.per_RFU import (
     PerRFUOutcomeMetric,
     compute_binned_f1,
+    load_rfu_outcome_csv,
     load_rfu_outcome_npz,
+    write_rfu_outcome_csv,
     write_rfu_outcome_npz,
+    write_rfu_outcome_file,
+    compute_binned_f1_from_csv,
     compute_binned_f1_from_npz,
 )
 
@@ -63,6 +69,49 @@ def test_rfu_outcome_npz_round_trip(tmp_path):
     assert loaded["fn_rfus"].tolist() == pytest.approx([30.0])
 
 
+def test_rfu_outcome_csv_round_trip(tmp_path):
+    path = tmp_path / "per_rfu_outcomes.csv"
+    outcomes = {
+        "tp_rfus": torch.tensor([10.0, 11.0]),
+        "fp_rfus": torch.tensor([20.0]),
+        "fn_rfus": torch.tensor([30.0]),
+    }
+
+    write_rfu_outcome_csv(path, outcomes)
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert rows == [
+        {"outcome": "tp", "rfu": "10"},
+        {"outcome": "tp", "rfu": "11"},
+        {"outcome": "fp", "rfu": "20"},
+        {"outcome": "fn", "rfu": "30"},
+    ]
+
+    loaded = load_rfu_outcome_csv(path)
+    assert loaded["tp_rfus"].tolist() == pytest.approx([10.0, 11.0])
+    assert loaded["fp_rfus"].tolist() == pytest.approx([20.0])
+    assert loaded["fn_rfus"].tolist() == pytest.approx([30.0])
+
+
+def test_write_rfu_outcome_file_dispatches_by_extension(tmp_path):
+    outcomes = {
+        "tp_rfus": [10.0],
+        "fp_rfus": [20.0],
+        "fn_rfus": [30.0],
+    }
+
+    npz_path = write_rfu_outcome_file(tmp_path / "outcomes.npz", outcomes)
+    csv_path = write_rfu_outcome_file(tmp_path / "outcomes.csv", outcomes)
+
+    assert npz_path.exists()
+    assert csv_path.exists()
+
+    with pytest.raises(ValueError, match="must end with"):
+        write_rfu_outcome_file(tmp_path / "outcomes.txt", outcomes)
+
+
 def test_compute_binned_f1_from_saved_outcomes(tmp_path):
     path = tmp_path / "per_rfu_outcomes.npz"
     write_rfu_outcome_npz(
@@ -99,3 +148,20 @@ def test_compute_binned_f1_from_saved_outcomes(tmp_path):
         "recall": pytest.approx(0.5),
         "f1": pytest.approx(2 / 3),
     }
+
+
+def test_compute_binned_f1_from_saved_csv_outcomes(tmp_path):
+    path = tmp_path / "per_rfu_outcomes.csv"
+    write_rfu_outcome_csv(
+        path,
+        {
+            "tp_rfus": [10.0, 110.0],
+            "fp_rfus": [20.0],
+            "fn_rfus": [120.0],
+        },
+    )
+
+    assert compute_binned_f1_from_csv(path, [0.0, 100.0, 200.0]) == compute_binned_f1(
+        load_rfu_outcome_csv(path),
+        [0.0, 100.0, 200.0],
+    )


### PR DESCRIPTION
Adds an optional evaluation metric that saves a file to disk with the tp, fp and fn RFU values. These can be used to create distributions of precision, recall, and F1 score across any RFU windows.