### PR TITLE
Cleanup HIDDataset: add docstring, remove double property and fix tests

### DIFF
--- a/src/dnanet/data/hid_dataset.py
+++ b/src/dnanet/data/hid_dataset.py
@@ -55,7 +55,8 @@ if TYPE_CHECKING:
 class HIDDataset(Dataset, TransformableDataset):
     """Load HID files from a directory into an in-memory dataset.
 
-    This is the primary dataset class for forensic DNA profiles. It:
+    This is the primary dataset class for forensic DNA profiles. It can either load already parsed images (including
+    labels and ladders) from a cache directory or parses them from raw files. In the latter case, the following steps are taken:
     1. Walks a root directory for ``.hid`` files
     2. Filters to sample files (excluding ladders, controls)
     3. Matches each sample to its annotation and best ladder
@@ -68,14 +69,20 @@ class HIDDataset(Dataset, TransformableDataset):
 
     Args:
         root: Root directory containing HID files (searched recursively).
-        ladder_alleles_csv: CSV with expected ladder alleles per dye.
-        analysis_threshold_type: ``"DTH"`` (high) or ``"DTL"`` (low).
-        adjustment_of_annotations: ``"top"`` or ``"complete"`` peak adjustment,
+        scaling_strategy: Strategy to be used to scale the HID images, based on kit information.
+        dataset_strategy: Strategy to be used to collect files, annotations and other dataset related settings.
+        adjustment_of_annotations: How/whether to adjust the peak annotations: ``"top"`` or ``"complete"`` peak adjustment,
             or ``None`` to skip.
         limit: Maximum number of images to load.
-        skip_if_invalid_ladder: Skip images whose ladder fails to parse.
+        skip_if_invalid_ladder: If set to True, skip images whose ladder fails to parse.
         include_size_standard: Include the 6th dye channel in the data.
-        data_loading_strategy: ``"raw"``, ``"analyzed"``, or ``"superior"``.
+        data_loading_strategy: Determines which data columns to use when loading HID images: ``"raw"``, ``"analyzed"``,
+            or ``"superior"``.
+        transform: The transformation to be applied to the HID images.
+        load_in_memory: Whether to store the HID image data in memory.
+        cache_dir: The (optional) directory where a cache of the dataset is stored or where the cache will be written
+            to if loading from cache fails.
+        cache_mode: Whether to cache the entire data or only the object's structure: ``"full"`` or ``"shell"``.
     """
 
     def __init__(
@@ -139,7 +146,7 @@ class HIDDataset(Dataset, TransformableDataset):
 
     # -- Cache and file loading -------------------------------------------- #
 
-    def _load_cache(self, cache_dir: Path, cache_mode: CacheMode):
+    def _load_cache(self, cache_dir: Path, cache_mode: CacheMode) -> Optional[Path]:
         # Cache setup
         _cache_path: Path | None = None
         if cache_dir is not None:
@@ -167,7 +174,7 @@ class HIDDataset(Dataset, TransformableDataset):
                 logger.info('Cache hit: loaded {} images from {}', len(self._data), _cache_path)
             except Exception as exc:
                 logger.warning('Cache read failed ({}), falling through to fresh load', exc)
-                # Do we want to remove cache if reading fails?
+                # TODO: Do we want to remove cache if reading fails?
                 # _cache_path.unlink(missing_ok=True)
                 self._data = []
         return _cache_path
@@ -186,21 +193,15 @@ class HIDDataset(Dataset, TransformableDataset):
         self, file_entries: List[Tuple[Path, Annotation | None, Path | None]]
     ) -> Generator[HIDImage, None, None]:
         """Create HIDImage instances, loading data and filtering invalid ones."""
-        ladder_cache: dict[str, Panel | None] = {}
-
         skipped_data = 0
         skipped_alleles = 0
         skipped_ladder = 0
 
-        for entry in tqdm(
+        for path, annotation, ladder_path in tqdm(
             file_entries,
             desc='Loading images',
             total=len(file_entries),
         ):
-            path: Path = entry[0]
-            ladder_path: Path | None = entry[2]
-            annotation = entry[1]  # (name, file) or None
-
             if isinstance(annotation, AlleleAnnotation):
                 allele_annotation = annotation
             else:
@@ -382,11 +383,7 @@ class HIDDataset(Dataset, TransformableDataset):
 
     @property
     def images(self) -> List[HIDImage]:
-        return self._data
-
-    @property
-    def data(self) -> List[HIDImage]:
-        """Protected property list of HIDImages in the dataset."""
+        """Protected property for the list of HIDImages in the dataset."""
         return self._data
 
     @property

--- a/tests/data/test_hid_dataset.py
+++ b/tests/data/test_hid_dataset.py
@@ -12,7 +12,7 @@ def _make_hid_dataset(**kwargs) -> HIDDataset:
     return HIDDataset(
         root=RD_DIR,
         scaling_strategy=PowerPlexFusion6CStrategy(),
-        dataset_strategy=NFIRnDStrategy(),
+        dataset_strategy=NFIRnDStrategy("DTH"),
         **kwargs,
     )
 
@@ -45,11 +45,11 @@ class TestHIDDatasetValidation:
     def test_empty_root_raises(self, nfi_rnd_kit, tmp_path):
         empty_dir = tmp_path / 'empty'
         empty_dir.mkdir()
-        with pytest.raises(ValueError, match="Path does not contain the neccessary mapping"):
+        with pytest.raises(ValueError, match="Path does not contain the necessary ladder mapping"):
             HIDDataset(
                 root=empty_dir,
                 scaling_strategy=PowerPlexFusion6CStrategy(),
-                dataset_strategy=NFIRnDStrategy(),
+                dataset_strategy=NFIRnDStrategy("DTH"),
             )
 
 
@@ -60,8 +60,8 @@ class TestHIDDatasetValidation:
 class TestHIDDatasetIntegration:
     def test_load_from_rd_dir(self, nfi_rnd_kit):
         """Load from test resources — should find 2 sample HID files."""
-        ds = _make_hid_dataset(analysis_threshold_type='DTH')
-        assert len(ds) >= 1  # at least one sample should load
+        ds = _make_hid_dataset()
+        assert len(ds) == 2
 
     def test_images_have_correct_shape(self, nfi_rnd_kit):
         ds = _make_hid_dataset()

--- a/tests/resources/profiles/RD/best_ladder_paths.csv
+++ b/tests/resources/profiles/RD/best_ladder_paths.csv
@@ -1,3 +1,3 @@
 image_path,ladder_path
-1A2_A01_01,tests/resources/profiles/RD/Ladder_G03_21.hid
-1A2_E01_13,tests/resources/profiles/RD/Ladder_G03_21.hid
+1A2_A01_01,Ladder_G03_21.hid
+1A2_E01_13,Ladder_G03_21.hid


### PR DESCRIPTION
Clean up HIDDataset:
* Update the init docstring
* Fix tests: adapt ladder paths csv, fix spelling mistake, set DTH argument 
* Remove double property (data vs. images, I removed the first as this appeared unused)