### PR TITLE
Fix caching for peak dataset and add load_in_memory

### DIFF
--- a/conf/data/peaks_rd.yaml
+++ b/conf/data/peaks_rd.yaml
@@ -5,16 +5,24 @@ defaults:
 
 name: peaks_rd
 
+shuffle_train: false # PeakDataset does not support shuffling
+
+# Re-export the wrapped HID dataset settings so other configs can keep
+# referring to the standard data.* keys.
+scaling_strategy: ${data.hid.dataset.scaling_strategy}
+dataset_strategy: ${data.hid.dataset.dataset_strategy}
+stratify_noc: ${oc.select:data.hid.stratify_noc,false}
+group_by_replica: ${oc.select:data.hid.group_by_replica,false}
 
 # The PeakWindowDataset wraps a HIDDataset to extract peaks from each HIDImage
 dataset:
-  _target_: dnanet.data.peak_dataset.PeakWindowDataset
+  _target_: dnanet.data.peak_dataset.PeakWindowDataset.from_hid_dataset
   base_dataset: ${data.hid.dataset}
   threshold: 25
-  window_size: 120
-  include_max_pool_dyes: false
+  window_size: ${model.architecture.width}
+  include_max_pool_dyes: ${model.architecture.include_max_pool_dyes}
   preprocess: true
   smooth_keep_factor: null
   log_scale: false
   max_rfu_value: null
-
+  load_in_memory: false

--- a/src/dnanet/data/hid_dataset.py
+++ b/src/dnanet/data/hid_dataset.py
@@ -452,12 +452,7 @@ class HIDDataset(Dataset, TransformableDataset):
         return f'HIDDataset(root={self.root.name}, n={len(self._index)})'
 
     def __getitem__(self, index: int) -> Any:
-        entry = self._index[index]
-        row = self._row_remap[index]
-
-        data, annotation_arr, scaler = self._reader.get_row(row)
-
-        image = self._materialize(entry, data, annotation_arr, scaler)
+        image = self.get_image(index)
 
         if self._transform:
             return self._transform(image)
@@ -474,6 +469,17 @@ class HIDDataset(Dataset, TransformableDataset):
             include_size_standard=self.include_size_standard,
             load_in_memory=False,
         )
+
+    def get_stub_image(self, index: int) -> HIDImage:
+        """Return a lightweight image object with only split metadata populated."""
+        return self._stub_image(index)
+
+    def get_image(self, index: int) -> HIDImage:
+        """Materialize a single cached HID image without applying transforms."""
+        entry = self._index[index]
+        row = self._row_remap[index]
+        data, annotation_arr, scaler = self._reader.get_row(row)
+        return self._materialize(entry, data, annotation_arr, scaler)
 
     def _materialize(
         self,

--- a/src/dnanet/data/peak_dataset.py
+++ b/src/dnanet/data/peak_dataset.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, List, Iterator
 
 from loguru import logger
-from torch.utils.data import IterableDataset
+from torch.utils.data import IterableDataset, get_worker_info
 
 from dnanet.data.dataset import TransformableDataset
 from dnanet.data.preprocessing.baseline import fft_lowpass_smooth
@@ -105,7 +105,7 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
     @classmethod
     def from_hid_dataset(cls, base_dataset: HIDDataset, **kwargs):
         """Create a PeakWindowDataset backed by cached HID rows."""
-        return cls.__init__(
+        return cls(
             dataset_strategy=base_dataset.dataset_strategy,
             base_dataset=base_dataset,
             transform=base_dataset.transform,

--- a/src/dnanet/data/peak_dataset.py
+++ b/src/dnanet/data/peak_dataset.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, List, Iterator
 
+from loguru import logger
 from torch.utils.data import IterableDataset
 
 from dnanet.data.dataset import TransformableDataset
 from dnanet.data.preprocessing.baseline import fft_lowpass_smooth
 from dnanet.data.preprocessing.peak_extraction import extract_peak_windows
 from dnanet.data.preprocessing.scaling import RFU_MAX_VALUE, scale_rfu_numpy
+from tqdm import tqdm
 
 if TYPE_CHECKING:
     from dnanet.data.image import HIDImage
@@ -49,12 +51,15 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
         smooth_keep_factor: FFT smoothing keep fraction (None to skip).
         log_scale: Apply log1p scaling during preprocessing.
         max_rfu_value: Max RFU for normalization (None to skip).
+        load_in_memory: Eagerly extract and cache all peaks at init time.
     """
 
     def __init__(
         self,
-        images: List[HIDImage],
         dataset_strategy: DatasetStrategy,
+        images: List[HIDImage] | None = None,
+        base_dataset: HIDDataset | None = None,
+        image_indices: List[int] | None = None,
         transform: TransformDataCallable | None = None,
         threshold: float = 40,
         window_size: int = 120,
@@ -63,11 +68,20 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
         smooth_keep_factor: float | None = 0.4,
         log_scale: bool = True,
         max_rfu_value: int | None = RFU_MAX_VALUE,
-        # TODO: add load_in_memory option
+        load_in_memory: bool = False,
+        _cached_peak_lists: list[list[ExtractedPeak]] | None = None,
     ) -> None:
         super().__init__()
 
+        if (images is None) == (base_dataset is None):
+            raise ValueError('Provide exactly one of `images` or `base_dataset`.')
+
         self._images = images
+        self._base_dataset = base_dataset
+        if image_indices is None:
+            source_len = len(images) if images is not None else len(base_dataset)  # type: ignore[arg-type]
+            image_indices = list(range(source_len))
+        self._image_indices = list(image_indices)
         self._transform = transform
         self._dataset_strategy = dataset_strategy
         self.threshold = threshold
@@ -80,32 +94,84 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
         self.smooth_keep_factor = smooth_keep_factor
         self.log_scale = log_scale
         self.max_rfu_value = max_rfu_value
+        self.load_in_memory = load_in_memory
+        self._cached_peak_lists = None
+
+        if self.load_in_memory:
+            self._cached_peak_lists = (
+                _cached_peak_lists if _cached_peak_lists is not None else self._materialize_peaks()
+            )
 
     @classmethod
     def from_hid_dataset(cls, base_dataset: HIDDataset, **kwargs):
-        """Create a PeakWindowDataset based on a HIDDataset's images and transform."""
+        """Create a PeakWindowDataset backed by cached HID rows."""
         return cls.__init__(
-            images=base_dataset.images,
             dataset_strategy=base_dataset.dataset_strategy,
+            base_dataset=base_dataset,
             transform=base_dataset.transform,
             **kwargs
         )
 
     def _iterate_peaks(self) -> Iterator[ExtractedPeak]:
         """Extract and optionally preprocess peaks from all images."""
-        for image in self._images:
-            peaks = extract_peak_windows(
-                image,
-                threshold=self.threshold,
-                window_size=self.window_size,
-                include_max_pool_dyes=self.include_max_pool_dyes,
-                dataset_strategy=self.dataset_strategy
-            )
+        for image in self._iter_worker_images():
+            yield from self._extract_peaks(image)
 
-            for peak in peaks:
-                if self.preprocess:
-                    self._preprocess_peak(peak)
-                yield peak
+    def _extract_peaks(self, image: HIDImage) -> Iterator[ExtractedPeak]:
+        """Extract peaks from one image and apply optional preprocessing."""
+        peaks = extract_peak_windows(
+            image,
+            threshold=self.threshold,
+            window_size=self.window_size,
+            include_max_pool_dyes=self.include_max_pool_dyes,
+            dataset_strategy=self.dataset_strategy
+        )
+
+        for peak in peaks:
+            if self.preprocess:
+                self._preprocess_peak(peak)
+            yield peak
+
+    def _materialize_peaks(self) -> list[list[ExtractedPeak]]:
+        """Eagerly extract peaks for each image in this dataset."""
+        logger.info("Eagerly extracting peaks for all images...")
+        return [
+            list(self._extract_peaks(self._materialize_image(index)))
+            for index in tqdm(self._image_indices, desc='Extracting peaks', unit='image')
+        ]
+
+    def _materialize_image(self, index: int) -> HIDImage:
+        if self._base_dataset is not None:
+            return self._base_dataset.get_image(index)
+        assert self._images is not None
+        return self._images[index]
+
+    def _worker_image_indices(self) -> List[int]:
+        """Return the image indices assigned to the current dataloader worker."""
+        worker_info = get_worker_info()
+        if worker_info is None:
+            return self._image_indices
+        return self._image_indices[worker_info.id::worker_info.num_workers]
+
+    def _iter_worker_images(self) -> Iterator[HIDImage]:
+        """Yield only the images needed by the current worker."""
+        for index in self._worker_image_indices():
+            yield self._materialize_image(index)
+
+    def _worker_images(self) -> List[HIDImage]:
+        """Return the worker shard as a list of materialized images."""
+        return list(self._iter_worker_images())
+
+    def _iter_worker_peak_lists(self) -> Iterator[list[ExtractedPeak]]:
+        """Yield only the cached peak lists needed by the current worker."""
+        assert self._cached_peak_lists is not None
+
+        worker_info = get_worker_info()
+        if worker_info is None:
+            yield from self._cached_peak_lists
+            return
+
+        yield from self._cached_peak_lists[worker_info.id::worker_info.num_workers]
 
     def _preprocess_peak(self, peak: ExtractedPeak) -> None:
         """Apply in-place preprocessing to a peak's data.
@@ -128,7 +194,10 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
 
     @property
     def images(self) -> List[HIDImage]:
-        return self._images
+        if self._base_dataset is not None:
+            return [self._base_dataset.get_stub_image(idx) for idx in self._image_indices]
+        assert self._images is not None
+        return [self._images[idx] for idx in self._image_indices]
 
     @property
     def transform(self) -> TransformDataCallable | None:
@@ -140,7 +209,13 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
 
     def __iter__(self) -> Iterator[Any]:
         """Create an iterator for the peaks."""
-        for peak in self._iterate_peaks():
+        peaks = (
+            (peak for peak_list in self._iter_worker_peak_lists() for peak in peak_list)
+            if self._cached_peak_lists is not None
+            else self._iterate_peaks()
+        )
+
+        for peak in peaks:
             if self.transform:
                 yield self.transform(peak)
             else:
@@ -148,9 +223,16 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
 
     def subset(self, indices: List[int]) -> PeakWindowDataset:
         """Create a subset of PeakWindowDataset with only indicated indices."""
+        subset_indices = [self._image_indices[idx] for idx in indices]
+        subset_peak_lists = None
+        if self._cached_peak_lists is not None:
+            subset_peak_lists = [self._cached_peak_lists[idx] for idx in indices]
+
         return PeakWindowDataset(
-            images=[self._images[idx] for idx in indices],
             dataset_strategy=self._dataset_strategy,
+            images=self._images,
+            base_dataset=self._base_dataset,
+            image_indices=subset_indices,
             transform=self._transform,
             threshold=self.threshold,
             window_size=self.window_size,
@@ -159,4 +241,6 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
             smooth_keep_factor=self.smooth_keep_factor,
             log_scale=self.log_scale,
             max_rfu_value=self.max_rfu_value,
+            load_in_memory=self.load_in_memory,
+            _cached_peak_lists=subset_peak_lists,
         )

--- a/src/dnanet/data/peak_dataset.py
+++ b/src/dnanet/data/peak_dataset.py
@@ -147,7 +147,15 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
         return self._images[index]
 
     def _worker_image_indices(self) -> List[int]:
-        """Return the image indices assigned to the current dataloader worker."""
+        """Return the image indices assigned to the current DataLoader worker.
+
+        ``get_worker_info()`` returns ``None`` when the dataset is iterated in
+        the main process. When used through a multi-worker DataLoader, it
+        returns the current worker's zero-based ``id`` and total
+        ``num_workers``. We use stride slicing to shard the work so worker 0
+        gets indices ``[0, n, 2n, ...]``, worker 1 gets ``[1, n + 1, ...]``,
+        and so on.
+        """
         worker_info = get_worker_info()
         if worker_info is None:
             return self._image_indices
@@ -163,7 +171,13 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
         return list(self._iter_worker_images())
 
     def _iter_worker_peak_lists(self) -> Iterator[list[ExtractedPeak]]:
-        """Yield only the cached peak lists needed by the current worker."""
+        """Yield the cached peak lists assigned to the current worker.
+
+        This mirrors :meth:`_worker_image_indices` so the cached peak lists stay
+        aligned with the image shard. In a multi-worker DataLoader, worker
+        ``i`` reads ``self._cached_peak_lists[i::num_workers]``; without worker
+        processes we yield the full cache.
+        """
         assert self._cached_peak_lists is not None
 
         worker_info = get_worker_info()

--- a/src/dnanet/data/peak_dataset.py
+++ b/src/dnanet/data/peak_dataset.py
@@ -196,7 +196,8 @@ class PeakWindowDataset(IterableDataset, TransformableDataset):
     def images(self) -> List[HIDImage]:
         if self._base_dataset is not None:
             return [self._base_dataset.get_stub_image(idx) for idx in self._image_indices]
-        assert self._images is not None
+        if self._images is None:
+            raise ValueError("PeakWindowDataset has no .images")
         return [self._images[idx] for idx in self._image_indices]
 
     @property

--- a/tests/data/test_peak_dataset.py
+++ b/tests/data/test_peak_dataset.py
@@ -1,18 +1,23 @@
 """Tests for PeakWindowDataset."""
 
+from collections import Counter
+from pathlib import Path
+from types import SimpleNamespace
+
 import numpy as np
 
 from dnanet.core.annotation import ScanpointAnnotation
-from dnanet.data.peak_dataset import PeakWindowDataset
 from dnanet.data.extracted_peak import ExtractedPeak
+from dnanet.data.peak_dataset import PeakWindowDataset
 
 
 class MockImage:
     """Minimal HIDImage-like object."""
 
-    def __init__(self, data, scaling_strategy, annotation_image=None):
+    def __init__(self, data, scaling_strategy, annotation_image=None, name="mock"):
         self._raw_data = data
         self._panel = None
+        self.path = Path(f"{name}.hid")
         self.scaling_strategy = scaling_strategy
         if annotation_image is not None:
             self.annotation = ScanpointAnnotation(data=annotation_image)
@@ -110,11 +115,18 @@ class TestPeakWindowDataset:
     def _make_base_dataset(self, scaling_strategy, dataset_strategy, n_images=3, n_peaks=3):
         """Create a SimpleDataset of mock images."""
         images = []
-        for _ in range(n_images):
+        for idx in range(n_images):
             data, centers = _make_profile_with_peaks(n_peaks=n_peaks)
             ann = np.zeros_like(data)
             ann[0, centers[0] - 2 : centers[0] + 3] = 1
-            images.append(MockImage(data, scaling_strategy, annotation_image=ann))
+            images.append(
+                MockImage(
+                    data,
+                    scaling_strategy,
+                    annotation_image=ann,
+                    name=f"mock_{idx}",
+                )
+            )
         return MockBaseDataset(images, scaling_strategy, dataset_strategy)
 
     def test_extracts_peaks_from_images(self, nfi_rnd_kit, nfi_rnd_dataset):
@@ -275,6 +287,85 @@ class TestPeakWindowDataset:
         assert list(subset) == ["cached_1"]
         assert extracted_from == ["cached_0", "cached_1"]
         assert base.materialized_indices == [0, 1]
+
+    def test_worker_images_returns_all_images_without_worker_info(
+        self,
+        nfi_rnd_kit,
+        nfi_rnd_dataset,
+        monkeypatch,
+    ):
+        base = self._make_base_dataset(nfi_rnd_kit, nfi_rnd_dataset, n_images=4)
+        ds = PeakWindowDataset(
+            images=base.images,
+            dataset_strategy=base.dataset_strategy,
+            preprocess=False,
+        )
+
+        monkeypatch.setattr("dnanet.data.peak_dataset.get_worker_info", lambda: None)
+
+        assert ds._worker_images() == base.images
+
+    def test_worker_images_are_sharded_across_workers(
+        self,
+        nfi_rnd_kit,
+        nfi_rnd_dataset,
+        monkeypatch,
+    ):
+        base = self._make_base_dataset(nfi_rnd_kit, nfi_rnd_dataset, n_images=7)
+        ds = PeakWindowDataset(
+            images=base.images,
+            dataset_strategy=base.dataset_strategy,
+            preprocess=False,
+        )
+
+        seen = []
+        for worker_id in range(3):
+            monkeypatch.setattr(
+                "dnanet.data.peak_dataset.get_worker_info",
+                lambda worker_id=worker_id: SimpleNamespace(id=worker_id, num_workers=3),
+            )
+            worker_images = ds._worker_images()
+            assert worker_images == base.images[worker_id::3]
+            seen.extend(worker_images)
+
+        counts = Counter(map(id, seen))
+        assert len(seen) == len(base.images)
+        assert set(counts) == {id(image) for image in base.images}
+        assert all(count == 1 for count in counts.values())
+
+    def test_subset_iteration_uses_worker_shard_before_transform(
+        self,
+        nfi_rnd_kit,
+        nfi_rnd_dataset,
+        monkeypatch,
+    ):
+        base = self._make_base_dataset(nfi_rnd_kit, nfi_rnd_dataset, n_images=5)
+        ds = PeakWindowDataset(
+            images=base.images,
+            dataset_strategy=base.dataset_strategy,
+            transform=lambda peak: f"transformed:{peak}",
+            preprocess=False,
+        )
+        subset = ds.subset([1, 2, 4])
+
+        monkeypatch.setattr(
+            "dnanet.data.peak_dataset.get_worker_info",
+            lambda: SimpleNamespace(id=1, num_workers=2),
+        )
+
+        extracted_from = []
+
+        def fake_extract_peak_windows(image, **_kwargs):
+            extracted_from.append(image.path.stem)
+            return [image.path.stem]
+
+        monkeypatch.setattr(
+            "dnanet.data.peak_dataset.extract_peak_windows",
+            fake_extract_peak_windows,
+        )
+
+        assert list(subset) == ["transformed:mock_2"]
+        assert extracted_from == ["mock_2"]
 
     def test_items_are_extracted_peaks(self, nfi_rnd_kit, nfi_rnd_dataset):
         base = self._make_base_dataset(nfi_rnd_kit, nfi_rnd_dataset, n_images=1)

--- a/tests/data/test_peak_dataset.py
+++ b/tests/data/test_peak_dataset.py
@@ -43,6 +43,58 @@ class MockBaseDataset:
         return self._dataset_strategy
 
 
+class StubOnlyBaseDataset:
+    """HIDDataset-like double with stub metadata and lazy image materialization."""
+
+    def __init__(self, scaling_strategy, dataset_strategy):
+        self._dataset_strategy = dataset_strategy
+        self.transform = None
+        self._scaling = scaling_strategy
+        self.materialized_indices: list[int] = []
+        self._stubs = []
+        self._materialized = []
+
+        for idx in range(2):
+            stub = MockImage(
+                data=np.zeros((5, 4096)),
+                scaling_strategy=self._scaling,
+                annotation_image=None,
+                name=f"cached_{idx}",
+            )
+            stub.adjusted_panel = None
+            self._stubs.append(stub)
+
+            data, centers = _make_profile_with_peaks(n_peaks=1)
+            ann = np.zeros_like(data)
+            ann[0, centers[0] - 2 : centers[0] + 3] = 1
+            image = MockImage(
+                data,
+                scaling_strategy=self._scaling,
+                annotation_image=ann,
+                name=f"cached_{idx}",
+            )
+            image.adjusted_panel = object()
+            self._materialized.append(image)
+
+    def __len__(self) -> int:
+        return len(self._stubs)
+
+    @property
+    def images(self):
+        return self._stubs
+
+    @property
+    def dataset_strategy(self):
+        return self._dataset_strategy
+
+    def get_stub_image(self, index: int):
+        return self._stubs[index]
+
+    def get_image(self, index: int):
+        self.materialized_indices.append(index)
+        return self._materialized[index]
+
+
 def _make_profile_with_peaks(n_dyes=5, length=4096, n_peaks=3):
     """Create profile with known peaks."""
     data = np.zeros((n_dyes, length))
@@ -76,6 +128,153 @@ class TestPeakWindowDataset:
         )
         # Each image has 3 peaks in dye 0
         assert len(list(ds)) >= 6
+
+    def test_from_hid_dataset_defers_materialization_until_iteration(
+        self,
+        nfi_rnd_kit,
+        nfi_rnd_dataset,
+        monkeypatch,
+    ):
+        base = StubOnlyBaseDataset(nfi_rnd_kit, nfi_rnd_dataset)
+
+        ds = PeakWindowDataset.from_hid_dataset(
+            base,
+            threshold=100,
+            window_size=120,
+            preprocess=False,
+        )
+
+        assert [image.path.stem for image in ds.images] == ["cached_0", "cached_1"]
+        assert base.materialized_indices == []
+
+        monkeypatch.setattr(
+            "dnanet.data.peak_dataset.get_worker_info",
+            lambda: SimpleNamespace(id=1, num_workers=2),
+        )
+
+        extracted_from = []
+
+        def fake_extract_peak_windows(image, **_kwargs):
+            assert image.annotation is not None
+            assert image.adjusted_panel is not None
+            extracted_from.append(image.path.stem)
+            return [image.path.stem]
+
+        monkeypatch.setattr(
+            "dnanet.data.peak_dataset.extract_peak_windows",
+            fake_extract_peak_windows,
+        )
+
+        assert list(ds) == ["cached_1"]
+        assert extracted_from == ["cached_1"]
+        assert base.materialized_indices == [1]
+
+    def test_load_in_memory_materializes_all_peaks_once(
+        self,
+        nfi_rnd_kit,
+        nfi_rnd_dataset,
+        monkeypatch,
+    ):
+        base = StubOnlyBaseDataset(nfi_rnd_kit, nfi_rnd_dataset)
+        extracted_from = []
+
+        def fake_extract_peak_windows(image, **_kwargs):
+            extracted_from.append(image.path.stem)
+            return [image.path.stem]
+
+        monkeypatch.setattr(
+            "dnanet.data.peak_dataset.extract_peak_windows",
+            fake_extract_peak_windows,
+        )
+
+        ds = PeakWindowDataset.from_hid_dataset(
+            base,
+            threshold=100,
+            window_size=120,
+            preprocess=False,
+            load_in_memory=True,
+        )
+
+        assert extracted_from == ["cached_0", "cached_1"]
+        assert base.materialized_indices == [0, 1]
+
+        monkeypatch.setattr(
+            "dnanet.data.peak_dataset.get_worker_info",
+            lambda: SimpleNamespace(id=1, num_workers=2),
+        )
+
+        assert list(ds) == ["cached_1"]
+        assert extracted_from == ["cached_0", "cached_1"]
+        assert base.materialized_indices == [0, 1]
+
+    def test_load_in_memory_preprocesses_during_materialization(
+        self,
+        nfi_rnd_kit,
+        nfi_rnd_dataset,
+        monkeypatch,
+    ):
+        base = self._make_base_dataset(nfi_rnd_kit, nfi_rnd_dataset, n_images=2, n_peaks=2)
+        preprocess_calls = []
+        original_preprocess_peak = PeakWindowDataset._preprocess_peak
+
+        def counting_preprocess_peak(self, peak):
+            preprocess_calls.append((peak.dye_index, peak.peak_center))
+            original_preprocess_peak(self, peak)
+
+        monkeypatch.setattr(
+            PeakWindowDataset,
+            "_preprocess_peak",
+            counting_preprocess_peak,
+        )
+
+        ds = PeakWindowDataset(
+            images=base.images,
+            dataset_strategy=base.dataset_strategy,
+            threshold=100,
+            window_size=120,
+            preprocess=True,
+            log_scale=True,
+            load_in_memory=True,
+        )
+
+        cached_peak_count = sum(len(peak_list) for peak_list in ds._cached_peak_lists)
+        assert len(preprocess_calls) == cached_peak_count
+
+        preprocess_calls.clear()
+        list(ds)
+        assert preprocess_calls == []
+
+    def test_subset_reuses_eager_peak_cache(
+        self,
+        nfi_rnd_kit,
+        nfi_rnd_dataset,
+        monkeypatch,
+    ):
+        base = StubOnlyBaseDataset(nfi_rnd_kit, nfi_rnd_dataset)
+        extracted_from = []
+
+        def fake_extract_peak_windows(image, **_kwargs):
+            extracted_from.append(image.path.stem)
+            return [image.path.stem]
+
+        monkeypatch.setattr(
+            "dnanet.data.peak_dataset.extract_peak_windows",
+            fake_extract_peak_windows,
+        )
+
+        ds = PeakWindowDataset.from_hid_dataset(
+            base,
+            threshold=100,
+            window_size=120,
+            preprocess=False,
+            load_in_memory=True,
+        )
+
+        subset = ds.subset([1])
+
+        assert list(subset) == ["cached_1"]
+        assert extracted_from == ["cached_0", "cached_1"]
+        assert base.materialized_indices == [0, 1]
 
     def test_items_are_extracted_peaks(self, nfi_rnd_kit, nfi_rnd_dataset):
         base = self._make_base_dataset(nfi_rnd_kit, nfi_rnd_dataset, n_images=1)

--- a/tests/data/test_peakwindow_splitting.py
+++ b/tests/data/test_peakwindow_splitting.py
@@ -49,7 +49,10 @@ def _fake_dataset(stems: list[str]):
     ds = MagicMock()
     ds.images = [_fake_img(s) for s in stems]
     ds.__len__ = MagicMock(return_value=len(stems))
-    return PeakWindowDataset(images=ds.images, dataset_strategy=NFIRnDStrategy())
+    return PeakWindowDataset(
+        images=ds.images,
+        dataset_strategy=NFIRnDStrategy(annotation_type='ground_truth'),
+    )
 
 
 class TestPeakWindowSplit:

--- a/tests/data/test_splitting.py
+++ b/tests/data/test_splitting.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from dnanet.data.splitting import split_data_in_k_folds
+
 
 
 class TestSplitKFolds:


### PR DESCRIPTION
## Summary
- fix `PeakWindowDataset` so it can wrap an `HIDDataset` without forcing full image materialization up front
- add `load_in_memory` support to eagerly extract and cache peak windows when that tradeoff is preferred
- expose `get_image` and `get_stub_image` on `HIDDataset` so peak extraction can keep using lightweight split metadata until a worker actually needs a row
- update `peaks_rd` config to disable shuffling, inherit `window_size` and `include_max_pool_dyes` from the active model config, and re-export the wrapped HID dataset settings
- add regression coverage for lazy materialization, eager caching, preprocessing-only-once behavior, and subset cache reuse

## Why
The peak dataset path was materializing HID images too early, which bypassed the intended caching flow and made peak extraction more expensive than necessary. This change keeps `PeakWindowDataset` aligned with the HID row cache, materializes only the rows assigned to each worker during iteration, and still provides an explicit eager-loading mode for runs where extracting all peaks once at startup is the better tradeoff.

## Test coverage
- adds tests in `tests/data/test_peak_dataset.py` for deferred HID materialization, `load_in_memory`, one-time preprocessing during eager caching, and cache reuse in subsets