### PR TITLE
Add selection of AT or LT annotations for NFI casework strategy

### DIFF
--- a/src/dnanet/data/strategies/datasets/nfi_casework.py
+++ b/src/dnanet/data/strategies/datasets/nfi_casework.py
@@ -187,16 +187,26 @@ class NFICaseStrategy(DatasetStrategy):
 
     @staticmethod
     def _is_correct_annotation_type(run_id: str, annotation_type: str, annotation_type_mapping: dict[str, str]) -> bool:
-        """Check if the run_id corresponds to the requested annotation type."""
+        """
+        Check if the run_id corresponds to the requested annotation type.
+
+        When a run_id ends with an L, it is assumed to be a LT profile.
+        When the run_id is found in the csv with an added L, it is also assumed to be a LT profile.
+        When a run_id does not end in an L, we check the type from the csv.
+        When the run_id is not found in the csv, we assume it is an AT profile.
+        """
         if annotation_type == 'ATLT':
             # when ATLT is selected, include all annotations
             return True
+        elif run_id.endswith('L'):
+            # assume the run-id is an LT profile if it ends with an L
+            return annotation_type == 'LT'
+        elif run_id + 'L' in annotation_type_mapping:
+            # sometimes the run-id is changed to end with an L, check also for this option.
+            return annotation_type == 'LT'
         elif run_id in annotation_type_mapping:
             # if the run-id is found in the csv, check if it matches the requested annotation type
             return annotation_type_mapping[run_id] == annotation_type
-        elif run_id + 'L' in annotation_type_mapping:
-            # sometimes the run-id is changed to end with an L, check also for this option.
-            return annotation_type_mapping[run_id + 'L'] == annotation_type
         elif annotation_type == 'AT':
             # if the run-id is not found in the csv, assume it is AT
             return True

--- a/src/dnanet/data/strategies/datasets/nfi_casework.py
+++ b/src/dnanet/data/strategies/datasets/nfi_casework.py
@@ -38,7 +38,16 @@ class NFICaseStrategy(DatasetStrategy):
     _ROBOT_NAMES = ('3500XL_A', '3500XL_B', '3500XL_C', '3500XL_D')
     _CACHE_DIR = Path('/tmp/.nfi_zaaksdata_cache/')
 
-    def __init__(self, annotation_type: str = 'DTH', robot_selection: Sequence[str] | None = None) -> None:
+    def __init__(self, annotation_type: str = 'ATLT', robot_selection: Sequence[str] | None = None) -> None:
+        """
+        Initialize the NFI casework strategy
+
+        Available annotation types:
+        - AT: only include profiles with a "high" analytical threshold (allele annotation)
+        - LT: only include profiles with a low threshold (allele annotation)
+        - ATLT: include profiles with either a high or low threshold (allele annotation)
+        - span: include profiles with a span annotation (scanpoint annotation)
+        """
         super().__init__()
         self.annotation_type = annotation_type
         self._robot_selection = robot_selection
@@ -105,8 +114,8 @@ class NFICaseStrategy(DatasetStrategy):
         # Collect all annotation .txt/.csv files and map from run_id -> annotation file
         if self.annotation_type == 'span':
             return self._collect_with_span_annotations(robots, path, scaling_strategy)
-        elif self.annotation_type == 'DTH' or self.annotation_type == 'DTL':
-            return self._collect_with_analyst_annotations(robots, path, scaling_strategy)
+        elif self.annotation_type == 'AT' or self.annotation_type == 'LT' or self.annotation_type == 'ATLT':
+            return self._collect_with_analyst_annotations(robots, path, scaling_strategy, self.annotation_type)
         else:
             raise ValueError(f'Invalid annotation type: {self.annotation_type}')
 
@@ -134,9 +143,19 @@ class NFICaseStrategy(DatasetStrategy):
         robots: Generator[Path, None, None],
         path: Path,
         scaling_strategy: ScalingStrategy,
+        annotation_type: str,
     ) -> Generator[Tuple[Path, AlleleAnnotation | None, Path | None], None, None]:
         annotations_folder = path / 'annotations'
         annotation_mapping = cls.find_annotation_files(annotations_folder)
+
+        # find what run_id corresponds to what annotation type (AT/LT/init) from runid_type.csv
+        run_id_path = path / 'runid_type.csv'
+        if not run_id_path.exists():
+            raise FileNotFoundError(f'Could not find runid_type.csv in {path}')
+        run_id_type_mapping = {
+            row[0]: row[1] for row in np.genfromtxt(run_id_path, delimiter=',', dtype=str)
+        }
+
 
         for _file in robots:
             if cls.categorize_file(_file.name) != 'sample':
@@ -145,23 +164,44 @@ class NFICaseStrategy(DatasetStrategy):
 
             _run_id = _file.stem.split('_')[0]
             _sample_name = _file.stem.rsplit('_', 1)[0]
-            _annotation = annotation_mapping.get(_run_id)
 
             _ladder = cls.find_ladder_for_sample(_file)
 
             _allele_annotation = None
-            if _annotation:
-                _allele_annotation_map = cls.parse_annotations(
-                    _annotation, scaling_strategy=scaling_strategy
-                )
+            if cls._is_correct_annotation_type(_run_id, annotation_type, run_id_type_mapping):
+                _annotation = annotation_mapping.get(_run_id)
 
-                # Usually there's only one sample <-> annotation per annotation file
-                if len(_allele_annotation_map) == 1:
-                    _allele_annotation = list(_allele_annotation_map.values())[0]
-                elif len(_allele_annotation_map) > 1:
-                    _allele_annotation = _allele_annotation_map[_sample_name]
+                if _annotation:
+                    _allele_annotation_map = cls.parse_annotations(
+                        _annotation, scaling_strategy=scaling_strategy
+                    )
+
+                    # Usually there's only one sample <-> annotation per annotation file
+                    if len(_allele_annotation_map) == 1:
+                        _allele_annotation = list(_allele_annotation_map.values())[0]
+                    elif len(_allele_annotation_map) > 1:
+                        _allele_annotation = _allele_annotation_map[_sample_name]
+
 
             yield (_file, _allele_annotation, _ladder)
+
+    @staticmethod
+    def _is_correct_annotation_type(run_id: str, annotation_type: str, annotation_type_mapping: dict[str, str]) -> bool:
+        """Check if the run_id corresponds to the requested annotation type."""
+        if annotation_type == 'ATLT':
+            # when ATLT is selected, include all annotations
+            return True
+        elif run_id in annotation_type_mapping:
+            # if the run-id is found in the csv, check if it matches the requested annotation type
+            return annotation_type_mapping[run_id] == annotation_type
+        elif run_id + 'L' in annotation_type_mapping:
+            # sometimes the run-id is changed to end with an L, check also for this option.
+            return annotation_type_mapping[run_id + 'L'] == annotation_type
+        elif annotation_type == 'AT':
+            # if the run-id is not found in the csv, assume it is AT
+            return True
+        # do not include LT profiles when AT is requested
+        return False
 
     def cache_signature(self) -> dict:  # noqa: D102
         return {

--- a/src/dnanet/data/strategies/datasets/nfi_rnd.py
+++ b/src/dnanet/data/strategies/datasets/nfi_rnd.py
@@ -56,7 +56,15 @@ class NFIRnDStrategy(DatasetStrategy):
     }
 
     def __init__(self, annotation_type: str):
-        """Initialize the NFI R&D dataset strategy."""
+        """
+        Initialize the NFI R&D dataset strategy.
+
+        Available annotation types:
+        - ground_truth: use ground truth annotations (allele annotation)
+        - DTH: use analyst annotations with "high" analytical threshold (allele annotation)
+        - DTL: use analyst annotations with low analytical threshold (allele annotation)
+        - span: use analyst span annotations (scanpoint annotation)
+        """
         self.annotation_type = annotation_type
 
         assert annotation_type in ['DTH', 'DTL', 'ground_truth', 'span'], (

--- a/tests/data/strategies/test_nfi_casework.py
+++ b/tests/data/strategies/test_nfi_casework.py
@@ -40,6 +40,7 @@ def mock_root(tmp_path):
     hids = tmp_path / 'hids'
     hids.mkdir()
     (tmp_path / 'annotations').mkdir()
+    (tmp_path / 'runid_type.csv').write_text('RUN001,AT\nRUN002,LT\n')
     robot_a = hids / '3500XL_A'
     (robot_a / 'sub1/sub2').mkdir(parents=True)
     (robot_a / 'sub1/sub2/sample_file.hid').touch()
@@ -65,6 +66,7 @@ class TestNFICaseStrategy:
         hids_folder.mkdir()
         annotations = dataset_root / 'annotations'
         annotations.mkdir()
+        (dataset_root / 'runid_type.csv').write_text('RUN001,AT\nRUN002,LT\n')
 
         robot_a = hids_folder / '3500XL_A'
         robot_a.mkdir(exist_ok=True)
@@ -79,7 +81,7 @@ class TestNFICaseStrategy:
         shutil.rmtree(dataset_root)
 
     def test_collect_dataset_files(self, _create_mock_dataset):
-        dataset_files = NFICaseStrategy('DTH')._collect_dataset_files_uncached(
+        dataset_files = NFICaseStrategy('ATLT')._collect_dataset_files_uncached(
             root_path=_create_mock_dataset,
             scaling_strategy=PowerPlexFusion6CStrategy(scanpoint_resolution=4096),
             folder_cache=False,
@@ -150,19 +152,56 @@ class TestCategorizeFile:
 
 class TestCacheSignature:
     def test_without_robot_selection(self):
-        sig = NFICaseStrategy('DTH').cache_signature()
+        sig = NFICaseStrategy('ATLT').cache_signature()
         assert sig['class'] == 'NFICaseStrategy'
         assert 'robot_selection' not in sig
-        assert sig['annotation_type'] == 'DTH'
+        assert sig['annotation_type'] == 'ATLT'
 
     def test_with_robot_selection(self):
-        sig = NFICaseStrategy('DTH', robot_selection=['3500XL_A', '3500XL_B']).cache_signature()
+        sig = NFICaseStrategy(
+            'ATLT',
+            robot_selection=['3500XL_A', '3500XL_B'],
+        ).cache_signature()
         assert 'robot_selection' in sig
         assert set(sig['robot_selection']) == {'3500XL_A', '3500XL_B'}
 
     def test_robot_selection_deduplicates(self):
-        sig = NFICaseStrategy('DTH', robot_selection=['3500XL_A', '3500XL_A']).cache_signature()
+        sig = NFICaseStrategy(
+            'ATLT',
+            robot_selection=['3500XL_A', '3500XL_A'],
+        ).cache_signature()
         assert len(sig['robot_selection']) == 1
+
+
+# ---------------------------------------------------------------------------
+# _is_correct_annotation_type
+# ---------------------------------------------------------------------------
+
+
+class TestIsCorrectAnnotationType:
+    @pytest.mark.parametrize(
+        ('run_id', 'annotation_type', 'annotation_type_mapping', 'expected'),
+        [
+            ('RUN001', 'ATLT', {'RUN001': 'AT'}, True),
+            ('RUN001L', 'LT', {}, True),
+            ('RUN001', 'LT', {'RUN001L': 'LT'}, True),
+            ('RUN001', 'AT', {'RUN001': 'AT'}, True),
+            ('RUN999', 'AT', {}, True),
+            ('RUN999', 'LT', {}, False),
+        ],
+    )
+    def test_matches_expected_annotation_type(
+        self,
+        run_id,
+        annotation_type,
+        annotation_type_mapping,
+        expected,
+    ):
+        assert NFICaseStrategy._is_correct_annotation_type(
+            run_id,
+            annotation_type,
+            annotation_type_mapping,
+        ) is expected
 
 
 # ---------------------------------------------------------------------------
@@ -320,7 +359,7 @@ class TestScanDirectoryStructure:
 
 class TestGetAnnotationClasses:
     def test_non_span_returns_noise_allele(self):
-        assert NFICaseStrategy('DTH').get_annotation_classes() == ['noise', 'allele']
+        assert NFICaseStrategy('ATLT').get_annotation_classes() == ['noise', 'allele']
 
     def test_span_returns_label_categories(self):
         assert NFICaseStrategy('span').get_annotation_classes() == LabelCategory.label_names()
@@ -422,14 +461,14 @@ class TestCollectDatasetFilesCached:
     def test_cache_miss_writes_cache(self, mock_root, scaling, tmp_path):
         cache_dir = tmp_path / 'cache'
         with patch.object(NFICaseStrategy, '_CACHE_DIR', cache_dir):
-            results = list(NFICaseStrategy('DTH').collect_dataset_files(mock_root, scaling))
+            results = list(NFICaseStrategy('ATLT').collect_dataset_files(mock_root, scaling))
         assert len(results) == 1
         assert len(list(cache_dir.glob('collect-*'))) == 1
 
     def test_cache_hit_skips_disk_scan(self, mock_root, scaling, tmp_path):
         cache_dir = tmp_path / 'cache'
         cache_dir.mkdir()
-        strategy = NFICaseStrategy('DTH')
+        strategy = NFICaseStrategy('ATLT')
         cache_key = hashlib.md5(
             json.dumps(
                 {
@@ -454,7 +493,7 @@ class TestCollectDatasetFilesCached:
         def _collect(robot_sel):
             with patch.object(NFICaseStrategy, '_CACHE_DIR', cache_dir):
                 return list(
-                    NFICaseStrategy('DTH', robot_selection=robot_sel).collect_dataset_files(
+                    NFICaseStrategy('ATLT', robot_selection=robot_sel).collect_dataset_files(
                         mock_root, scaling
                     )
                 )


### PR DESCRIPTION
It is now possible to select only AT, LT or both types of annotations when loading NFI casework data.