### PR TITLE
Small data loading and logging improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ annotations.csv
 # Don't commit caswork data config
 conf/data/*zaaksdata*.yaml
 conf/data/*casework*.yaml
-conf/data/*private*.yaml
+conf/**/*private*.yaml

--- a/conf/data/dnanet_rd.yaml
+++ b/conf/data/dnanet_rd.yaml
@@ -1,6 +1,7 @@
 # NFI R&D 2p/5p mixture dataset (PPF6C kit)
 name: dnanet_rd
 
+num_classes: 2
 # Dataset loading options
 dataset:
   _target_: dnanet.data.hid_dataset.HIDDataset

--- a/conf/data/provedit.yaml
+++ b/conf/data/provedit.yaml
@@ -1,7 +1,7 @@
 # PROVEDIt dataset (GlobalFiler kit)
 name: provedit
 
-
+num_classes: 2
 # Paths (relative to project root — adjust for your setup)
 dataset:
   _target_: dnanet.data.hid_dataset.HIDDataset
@@ -12,7 +12,7 @@ dataset:
   dataset_strategy:
     _target_: dnanet.data.strategies.datasets.ProvedItStrategy
   limit: null  # Set to integer to limit number of loaded images
-  skip_if_invalid_ladder: false
+  skip_if_invalid_ladder: true
   include_size_standard: true
   data_loading_strategy: superior  # raw, analyzed, or superior
   adjustment_of_annotations: top  # top, complete, or null

--- a/conf/evaluate/peaknet.yaml
+++ b/conf/evaluate/peaknet.yaml
@@ -13,15 +13,15 @@ metrics:
   metrics:
     scanpoint_precision:
       _target_: torchmetrics.classification.MulticlassPrecision
-      num_classes: ${model.num_classes}
+      num_classes: ${data.num_classes}
       average: macro
     scanpoint_recall:
       _target_: torchmetrics.classification.MulticlassRecall
-      num_classes: ${model.num_classes}
+      num_classes: ${data.num_classes}
       average: macro
     scanpoint_f1:
       _target_: torchmetrics.classification.MulticlassF1Score
-      num_classes: ${model.num_classes}
+      num_classes: ${data.num_classes}
       average: macro
 
 lightning_module: dnanet.modules.peaknet.PeakNetModule

--- a/conf/metrics/multi-class.yaml
+++ b/conf/metrics/multi-class.yaml
@@ -1,16 +1,16 @@
 precision:
   _target_: torchmetrics.classification.MulticlassPrecision
-  num_classes: ${model.num_classes}
+  num_classes: ${data.num_classes}
   average: macro
 recall:
   _target_: torchmetrics.classification.MulticlassRecall
-  num_classes: ${model.num_classes}
+  num_classes: ${data.num_classes}
   average: macro
 f1:
   _target_: torchmetrics.classification.MulticlassF1Score
-  num_classes: ${model.num_classes}
+  num_classes: ${data.num_classes}
   average: macro
 jaccard_index:
   _target_: torchmetrics.classification.MulticlassJaccardIndex
-  num_classes: ${model.num_classes}
+  num_classes: ${data.num_classes}
   average: macro

--- a/conf/model/multiclass_unet.yaml
+++ b/conf/model/multiclass_unet.yaml
@@ -12,7 +12,7 @@ architecture:
   depth: 4
   kernel_size: [3, 5]
   num_filters: 32
-  out_channels: ${model.num_classes}
+  out_channels: ${data.num_classes}
 
 loss:
   _target_: torch.nn.CrossEntropyLoss

--- a/conf/model/peak_classifier.yaml
+++ b/conf/model/peak_classifier.yaml
@@ -4,11 +4,11 @@ name: peak_classifier
 defaults:
   - /train@_global_.train: classification
 
-num_classes: 2
+
 
 architecture:
   _target_: dnanet.models.peak_classifier.PeakClassificationModel
-  num_classes: ${model.num_classes}
+  num_classes: ${data.num_classes}
   width: 120
   n_markers: 28
   embedding_dim: 8

--- a/conf/model/peaknet.yaml
+++ b/conf/model/peaknet.yaml
@@ -7,7 +7,6 @@ defaults:
 
 peak_threshold: 25
 window_size: 120
-num_classes: 2
 
 threshold: 25
 include_max_pool_dyes: False
@@ -33,7 +32,7 @@ architecture:
 
   peak_classifier:
     _target_: dnanet.models.peak_classifier.PeakClassificationModel
-    num_classes: ${model.num_classes}
+    num_classes: ${data.num_classes}
     width: ${model.window_size}
     n_markers: 28
     embedding_dim: 8
@@ -44,7 +43,7 @@ architecture:
     downsample: maxpool
 
   hidden_dims: [64, 32]
-  num_classes: ${model.num_classes}
+  num_classes: ${data.num_classes}
   default_class: 0
   freeze_autoencoder: false
   combiner: mlp           # mlp, film, or attention

--- a/conf/train/classification.yaml
+++ b/conf/train/classification.yaml
@@ -43,7 +43,7 @@ lightning_module:
   learning_rate: ${train.learning_rate}
   weight_decay: ${train.weight_decay}
   loss_fn: ${model.loss}
-  num_classes: ${model.num_classes}
+  num_classes: ${data.num_classes}
   metrics:
     _target_: torchmetrics.MetricCollection
     metrics: ${metrics}
@@ -53,7 +53,4 @@ data_module:
   _target_: dnanet.data.datamodule.DNANetDataModule
   batch_size: ${train.batch_size}
   num_workers: ${train.num_workers}
-  seed: ${train.seed}
-  stratify_noc: ${oc.select:data.stratify_noc,false}
-  group_by_replica: ${oc.select:data.group_by_replica,false}
   shuffle_train: ${oc.select:data.shuffle_train,true}

--- a/conf/train/peaknet.yaml
+++ b/conf/train/peaknet.yaml
@@ -36,7 +36,7 @@ lightning_module:
   learning_rate: ${train.learning_rate}
   weight_decay: ${train.weight_decay}
   loss_fn: ${model.loss}
-  num_classes: ${model.num_classes}
+  num_classes: ${data.num_classes}
   metrics:
     _target_: torchmetrics.MetricCollection
     metrics: ${metrics}

--- a/src/dnanet/data/datamodule.py
+++ b/src/dnanet/data/datamodule.py
@@ -28,6 +28,7 @@ class DNANetDataModule(L.LightningDataModule):
         dataset: TransformableDataset,
         batch_size: int = 16,
         num_workers: int = 0,
+        shuffle_train: bool = True,
         **split_kwargs,
     ) -> None:
         super().__init__()
@@ -36,6 +37,7 @@ class DNANetDataModule(L.LightningDataModule):
         self.batch_size = batch_size
         self.num_workers = num_workers
         self._split_kwargs = split_kwargs
+        self.shuffle_train = shuffle_train
 
         self._train_dataset: Dataset | None = None
         self._val_dataset: Dataset | None = None
@@ -75,7 +77,7 @@ class DNANetDataModule(L.LightningDataModule):
         return DataLoader(
             self._train_dataset,
             batch_size=self.batch_size,
-            shuffle=True,
+            shuffle=self.shuffle_train,
             num_workers=self.num_workers,
             collate_fn=self._collate_fn,
             persistent_workers=self.num_workers > 0,

--- a/src/dnanet/data/hid_dataset.py
+++ b/src/dnanet/data/hid_dataset.py
@@ -261,6 +261,7 @@ class HIDDataset(Dataset, TransformableDataset):
         """
         # Collect sources. This is used for (a) fingerprint validation and
         # (b) driving a fresh build; it's a cheap walk (stat-only).
+        logger.info('Looking for dataset cache...')
         file_entries = list(self._dataset_strategy.collect_dataset_files(self.root, self._scaling))
 
         if is_complete(self._cache_dir) and self._use_cache:

--- a/src/dnanet/data/hid_dataset.py
+++ b/src/dnanet/data/hid_dataset.py
@@ -262,7 +262,7 @@ class HIDDataset(Dataset, TransformableDataset):
         # Collect sources. This is used for (a) fingerprint validation and
         # (b) driving a fresh build; it's a cheap walk (stat-only).
         logger.info('Looking for dataset cache...')
-        file_entries = list(self._dataset_strategy.collect_dataset_files(self.root, self._scaling))
+        file_entries = list(self._dataset_strategy.collect_dataset_files(self.root, self._scaling, allow_missing_annotations=self.allow_missing_annotations))
 
         if is_complete(self._cache_dir) and self._use_cache:
             source_paths = [e[0] for e in file_entries]
@@ -299,12 +299,6 @@ class HIDDataset(Dataset, TransformableDataset):
                 remaining = file_entries
 
             for image in self._load_images(remaining):
-                if image.data is None or image.scaler is None:
-                    logger.debug('Skipping {} during cache build (no data/scaler)', image.path)
-                    continue
-                if image.annotation is None and not self.allow_missing_annotations:
-                    logger.debug('Skipping {} during cache build (no annotation)', image.path)
-                    continue
                 writer.write(image)
             writer.finalize(config_payload, source_paths)
 
@@ -399,7 +393,7 @@ class HIDDataset(Dataset, TransformableDataset):
                     'Adjust annotations is provided but direct ScanpointAnnotations are not adjusted'
                 )
                 scanpoint_annotation = annotation
-            if annotation is not None:
+            elif annotation is not None:
                 logger.info(f'Encountered unknown annotation type: {type(annotation)}')
                 scanpoint_annotation = annotation
             else:

--- a/src/dnanet/data/strategies/datasets/dataset.py
+++ b/src/dnanet/data/strategies/datasets/dataset.py
@@ -239,7 +239,7 @@ class DatasetStrategy(ABC):
         profiles = {row['profile'] for row in rows}
         categories = {row['category'] for row in rows}
 
-        logger.info(f'Found {len(rows)} valid span annotations in {len(profiles)} profiles')
+        logger.info(f'Found {len(rows)} valid span annotations in {len(profiles)} unique profiles')
         logger.info(f'Categories found in annotations: {categories}')
 
         # convert dye names to dye indices and category names to indices
@@ -316,7 +316,8 @@ class DatasetStrategy(ABC):
             dye_idx = int(row['dye_idx'])
             category_idx = int(row['category_idx'])
             if not 0 <= dye_idx < num_dyes:
-                raise ValueError(f'Dye index {dye_idx} outside annotation shape')
+                # raise ValueError(f'Dye index {dye_idx} outside annotation shape')
+                continue # FIXME parsing of y profiles fails
             if not 0 <= category_idx < num_classes:
                 raise ValueError(f'Category index {category_idx} outside annotation shape')
 

--- a/src/dnanet/data/strategies/datasets/nfi_casework.py
+++ b/src/dnanet/data/strategies/datasets/nfi_casework.py
@@ -10,40 +10,43 @@ Warning:
     Please see the documentation about developing your own strategy, or use the two other strategies for the open-source data.
 """
 
-import os
-import json
-import pickle
 import hashlib
 import itertools
-from typing import Dict, Tuple, Mapping, Callable, Sequence, Generator
+import json
+import os
+import pickle
 from pathlib import Path
+from typing import Dict, Tuple, Mapping, Callable, Sequence, Generator
 
 import numpy as np
 from loguru import logger
-from torch.utils.data import Subset
 from sklearn.model_selection import (
     KFold,
     train_test_split,
 )
+from torch.utils.data import Subset
+from tqdm import tqdm
 
-from dnanet.core.types import PathLike
+from dnanet.core.annotation import Annotation, AlleleAnnotation
+from dnanet.core.annotation import SpanAnnotation
 from dnanet.core.constants import LabelCategory
-from dnanet.core.annotation import Annotation, AlleleAnnotation, ScanpointAnnotation
-from dnanet.data.strategies.scaling.scaling import ScalingStrategy
+from dnanet.core.types import PathLike
 from dnanet.data.strategies.datasets.dataset import FileCategory, DatasetStrategy
 from dnanet.data.strategies.datasets.nfi_rnd import NFIRnDStrategy
+from dnanet.data.strategies.scaling.scaling import ScalingStrategy
 
 
 class NFICaseStrategy(DatasetStrategy):
     _ROBOT_NAMES = ('3500XL_A', '3500XL_B', '3500XL_C', '3500XL_D')
     _CACHE_DIR = Path('/tmp/.nfi_zaaksdata_cache/')
 
-    def __init__(
-        self,
-        annotation_type: str = 'ATLT',
-        robot_selection: Sequence[str] | None = None,
-        span_annotations_path: PathLike | None = None,
-    ) -> None:
+    def __init__(self,
+                 annotation_type: str = 'ATLT',
+                 robot_selection: Sequence[str] | None = None,
+                 span_annotations_path: PathLike | None = None,
+                 exclude_path: PathLike | None = None,
+        ) -> None:
+
         """Initialize the NFI casework strategy
 
         Available annotation types:
@@ -56,6 +59,7 @@ class NFICaseStrategy(DatasetStrategy):
         self.annotation_type = annotation_type
         self._robot_selection = robot_selection
         self._span_annotations_path = span_annotations_path
+        self._exclude_path = exclude_path
 
     def collect_dataset_files(
         self, root_path: str | Path, scaling_strategy: ScalingStrategy, **kwargs
@@ -94,6 +98,8 @@ class NFICaseStrategy(DatasetStrategy):
 
         results = list(self._collect_dataset_files_uncached(root_path, scaling_strategy))
 
+        logger.info(f'Found {len(results)} valid samples')
+
         cache_file.parent.mkdir(exist_ok=True, parents=True)
         with cache_file.open('wb') as f:
             pickle.dump(results, f)
@@ -109,17 +115,27 @@ class NFICaseStrategy(DatasetStrategy):
         path = Path(root_path)
 
         # Collect all .HID files from the robot folders
-        hids_folder = path / 'hids'
-        robots = self.find_robot_files(
-            hids_folder,
+        file_list = self.find_robot_files(
+            path,
             self._robot_selection,
             cache=folder_cache,
         )
+
+        file_list = list(file_list)
+        logger.info(f'Found {len(file_list)} .hid files in {path}')
+
+
         resolve_annotation = self._build_annotation_resolver(
             path, scaling_strategy, self.annotation_type, self._span_annotations_path
         )
+        if self._exclude_path:
+            with open(Path(self._exclude_path), 'r') as f:
+                exclude_files = [line.strip() for line in f if line.strip()]
+        for hid_file in tqdm(file_list, desc='Collecting HID files', unit='file', unit_scale=True, leave=False):
+            if self._exclude_path and hid_file.stem in exclude_files:
+                # logger.debug(f'Skipping excluded file: {hid_file.stem}')
+                continue
 
-        for hid_file in robots:
             file_category = self.categorize_file(hid_file.name)
             if file_category != 'sample':
                 logger.debug(f'Skipping {file_category} file: {hid_file.stem}')
@@ -133,7 +149,7 @@ class NFICaseStrategy(DatasetStrategy):
         cls,
         path: Path,
         scaling_strategy: ScalingStrategy,
-        annotation_type: str,
+        annotation_type: str | None,
         span_annotations_path: PathLike | None = None,
     ) -> Callable[[Path], Annotation | None]:
         """Build a per-HID annotation resolver for the configured annotation type.
@@ -155,6 +171,8 @@ class NFICaseStrategy(DatasetStrategy):
         Raises:
             ValueError: If ``self.annotation_type`` is not supported.
         """
+        if annotation_type is None:
+            return lambda hid_file: None
         if annotation_type == 'span':
             # parse span annotations
             if span_annotations_path is None:
@@ -162,7 +180,8 @@ class NFICaseStrategy(DatasetStrategy):
             span_annotations_path = Path(span_annotations_path)
             hid_to_annotation = cls._parse_span_annotation(span_annotations_path, scaling_strategy)
 
-            def resolve_annotation(hid_file: Path) -> ScanpointAnnotation | None:
+
+            def resolve_annotation(hid_file: Path) -> SpanAnnotation | None:
                 return hid_to_annotation.get(hid_file.stem)
 
             return resolve_annotation
@@ -260,31 +279,38 @@ class NFICaseStrategy(DatasetStrategy):
     @classmethod
     def find_robot_files(
         cls,
-        robots_folder: Path,
-        selected_robots: Sequence[str] | None = None,
+        data_folder: Path,
+        selected_subfolders: Sequence[str] | None = None,
         robot_limit: int | None = None,
         cache: bool = True,
     ) -> Generator[Path, None, None]:
         """Collect all files in the robot's casework folders.
 
         Args:
-            robots_folder: The root in which the robot folders reside
-            selected_robots: Allows for a subselection of robot folder names (e.g. `('3500XL_A',)`). Defaults to None.
+            data_folder: The root in which the robot folders reside
+            selected_subfolders: Allows for a subselection of folder names (e.g. `('3500XL_A',)`). Defaults to None.
             robot_limit: Limits the amount of files returned from a robot. Defaults to None.
             cache: Whether to use cache saved in /tmp/ to prevent walking the whole folder again between runs.
 
         Yields:
             File paths of .hid's found in the robot folders.
         """
-        robot_names = cls._ROBOT_NAMES if not selected_robots else selected_robots
-        for robot_name in robot_names:
-            robot_folder = robots_folder / robot_name
-            if not robot_folder.exists():
-                continue
-            logger.info(f'Retrieving files from {robot_name}')
+        if (data_folder / 'hids').exists():
+            data_folder = data_folder / 'hids'
+        if selected_subfolders is None:
+            logger.info(f'Retrieving files in {data_folder}')
             yield from itertools.islice(
-                cls._scan_directory_structure(robot_folder, cache=cache), robot_limit
+                cls._scan_directory_structure(data_folder, cache=cache), robot_limit
             )
+        else:
+            for subfolder in selected_subfolders:
+                robot_folder = data_folder / subfolder
+                if not robot_folder.exists():
+                    continue
+                logger.info(f'Retrieving files from {subfolder}')
+                yield from itertools.islice(
+                    cls._scan_directory_structure(robot_folder, cache=cache), robot_limit
+                )
 
     @classmethod
     def find_annotation_files(cls, annotations_folder: Path):  # noqa: D102
@@ -305,6 +331,7 @@ class NFICaseStrategy(DatasetStrategy):
                 return pickle.load(f)
 
         files = list(cls._scan_directory_structure_uncached(path))
+        logger.info(f'Found {len(files)} files in {path}')
 
         if cache:
             _cache_file.parent.mkdir(exist_ok=True, parents=True)

--- a/src/dnanet/data/strategies/datasets/nfi_casework.py
+++ b/src/dnanet/data/strategies/datasets/nfi_casework.py
@@ -42,12 +42,22 @@ class NFICaseStrategy(DatasetStrategy):
 
     def __init__(self,
                  annotation_type: str = 'ATLT',
-                 robot_selection: Sequence[str] | None = None,
+                 subfolder_selection: Sequence[str] | None = None,
                  span_annotations_path: PathLike | None = None,
                  exclude_path: PathLike | None = None,
-        ) -> None:
+                 shuffle_limit: int | None = None,
+                 seed: int | None = None,
+                 ) -> None:
 
         """Initialize the NFI casework strategy
+
+        Args:
+            annotation_type: The type of annotation to use. Defaults to 'ATLT'.
+            subfolder_selection: A list of subfolders to include. All subfolders are included when None. Defaults to None.
+            span_annotations_path: The path to the span annotations. When None, defaults to data_path/span_annotations
+            exclude_path: The path to a file containing a list of HID files to exclude. Defaults to None.
+            shuffle_limit: Optional limit of number of files to include after shuffling. Defaults to None.
+            seed: Optional seed for shuffling, is required when shuffle_limit is set. Defaults to None.
 
         Available annotation types:
         - AT: only include profiles with a "high" analytical threshold (allele annotation)
@@ -57,9 +67,11 @@ class NFICaseStrategy(DatasetStrategy):
         """
         super().__init__()
         self.annotation_type = annotation_type
-        self._robot_selection = robot_selection
+        self._subfolder_selection = subfolder_selection
         self._span_annotations_path = span_annotations_path
         self._exclude_path = exclude_path
+        self.shuffle_limit = shuffle_limit
+        self.seed = seed
 
     def collect_dataset_files(
         self, root_path: str | Path, scaling_strategy: ScalingStrategy, **kwargs
@@ -96,7 +108,14 @@ class NFICaseStrategy(DatasetStrategy):
                 yield from pickle.load(f)
             return
 
-        results = list(self._collect_dataset_files_uncached(root_path, scaling_strategy))
+        results = list(self._collect_dataset_files_uncached(root_path, scaling_strategy, **kwargs))
+
+        if self.shuffle_limit:
+            if not self.seed:
+                raise ValueError('shuffle_limit is set, but seed is not provided')
+            rng = np.random.default_rng(self.seed)
+            results = rng.choice(results, self.shuffle_limit, replace=False).tolist()
+
 
         logger.info(f'Found {len(results)} valid samples')
 
@@ -111,13 +130,15 @@ class NFICaseStrategy(DatasetStrategy):
         root_path: str | Path,
         scaling_strategy: ScalingStrategy,
         folder_cache: bool = True,
+        allow_missing_annotations: bool = True,
+        **kwargs
     ) -> Generator[Tuple[Path, Annotation | None, Path | None], None, None]:
         path = Path(root_path)
 
         # Collect all .HID files from the robot folders
         file_list = self.find_robot_files(
             path,
-            self._robot_selection,
+            self._subfolder_selection,
             cache=folder_cache,
         )
 
@@ -133,16 +154,18 @@ class NFICaseStrategy(DatasetStrategy):
                 exclude_files = [line.strip() for line in f if line.strip()]
         for hid_file in tqdm(file_list, desc='Collecting HID files', unit='file', unit_scale=True, leave=False):
             if self._exclude_path and hid_file.stem in exclude_files:
-                # logger.debug(f'Skipping excluded file: {hid_file.stem}')
                 continue
 
             file_category = self.categorize_file(hid_file.name)
             if file_category != 'sample':
-                logger.debug(f'Skipping {file_category} file: {hid_file.stem}')
+                continue
+
+            annotation = resolve_annotation(hid_file)
+            if annotation is None and not allow_missing_annotations:
                 continue
 
             ladder = self.find_ladder_for_sample(hid_file)
-            yield (hid_file, resolve_annotation(hid_file), ladder)
+            yield (hid_file, annotation, ladder)
 
     @classmethod
     def _build_annotation_resolver(
@@ -256,9 +279,13 @@ class NFICaseStrategy(DatasetStrategy):
         return {
             'class': self.__class__.__name__,
             'annotation_type': self.annotation_type,
+            'exclude_path': self._exclude_path,
+            'span_annotations_path': self._span_annotations_path,
+            'seed': self.seed,
+            'shuffle_limit': self.shuffle_limit,
             **(
-                {'robot_selection': tuple(set(self._robot_selection))}
-                if self._robot_selection
+                {'subfolder_selection': tuple(set(self._subfolder_selection))}
+                if self._subfolder_selection
                 else {}
             ),
         }

--- a/src/dnanet/data/strategies/datasets/nfi_rnd.py
+++ b/src/dnanet/data/strategies/datasets/nfi_rnd.py
@@ -59,6 +59,10 @@ class NFIRnDStrategy(DatasetStrategy):
     def __init__(self, annotation_type: str, span_annotations_path: PathLike | None = None):
         """Initialize the NFI R&D dataset strategy.
 
+        Args:
+            annotation_type: The type of annotation to use.
+            span_annotations_path: The path to the span annotations. When None, defaults to data_path/span_annotations
+
         Available annotation types:
         - ground_truth: use ground truth annotations (allele annotation)
         - DTH: use analyst annotations with "high" analytical threshold (allele annotation)

--- a/src/dnanet/data/strategies/datasets/nfi_rnd.py
+++ b/src/dnanet/data/strategies/datasets/nfi_rnd.py
@@ -56,7 +56,7 @@ class NFIRnDStrategy(DatasetStrategy):
         '6': ['Z', 'AA', 'AB', 'AC', 'AD'],
     }
 
-    def __init__(self, annotation_type: str):
+    def __init__(self, annotation_type: str, span_annotations_path: PathLike | None = None):
         """Initialize the NFI R&D dataset strategy.
 
         Available annotation types:
@@ -66,6 +66,7 @@ class NFIRnDStrategy(DatasetStrategy):
         - span: use analyst span annotations (scanpoint annotation)
         """
         self.annotation_type = annotation_type
+        self._span_annotations_path = span_annotations_path
 
         assert annotation_type in ['DTH', 'DTL', 'ground_truth', 'span'], (
             f'Invalid annotation type: {annotation_type}'
@@ -110,7 +111,10 @@ class NFIRnDStrategy(DatasetStrategy):
                     path, hid_file_samples, scaling_strategy
                 )
             case 'span':
-                span_annotations_path = path / 'span_annotations'
+                if self._span_annotations_path is None:
+                    span_annotations_path = path / 'span_annotations'
+                else:
+                    span_annotations_path = Path(self._span_annotations_path)
                 hid_to_annotation = self._parse_span_annotation(
                     span_annotations_path, scaling_strategy
                 )

--- a/src/dnanet/modules/peaknet.py
+++ b/src/dnanet/modules/peaknet.py
@@ -171,7 +171,8 @@ class PeakNetModule(BaseTaskModule):
         else:
             raise ValueError(
                 "PeakNetModule expects a nested (inputs, targets) batch, a flat "
-                "6-item batch, a metadata-augmented batch, or a 5-item input-only batch.",
+                "6-item batch, a metadata-augmented batch, or a 5-item input-only batch."
+                f" Got {len(batch)}.",
             )
 
         if len(inputs) != 5:

--- a/tests/data/strategies/test_nfi_casework.py
+++ b/tests/data/strategies/test_nfi_casework.py
@@ -283,7 +283,7 @@ class TestFindRobotFiles:
             folder.mkdir()
             (folder / 'file.hid').touch()
         files = list(
-            NFICaseStrategy.find_robot_files(tmp_path, selected_robots=['3500XL_A'], cache=False)
+            NFICaseStrategy.find_robot_files(tmp_path, selected_subfolders=['3500XL_A'], cache=False)
         )
         assert len(files) == 1
 


### PR DESCRIPTION
- Move `num_classes` param to data config
- Re-add `shuffle_train` param: PeakWindowDataset does not support shuffling because it does not have a get_item, only an iterator.
- Add some logging regarding loading of datasets
- Make loading of NFICaseData and span annotations more generic (paths can now be specified more easily)