### PR TITLE
Feature/multiclass allele calling

### DIFF
--- a/src/dnanet/evaluation/__init__.py
+++ b/src/dnanet/evaluation/__init__.py
@@ -13,12 +13,19 @@ from dnanet.evaluation.metrics import (
     AllelePrecision,
     PerRFUOutcomeMetric,
 )
-from dnanet.evaluation.allele_caller import AlleleCaller, NearestBasePairCaller
+from dnanet.evaluation.allele_caller import (
+    AlleleCaller,
+    ExactBasePairCaller,
+    FromSegmentationImageCaller,
+    NearestBasePairCaller,
+)
 
 
 __all__ = [
     "AlleleCaller",
+    "FromSegmentationImageCaller",
     "NearestBasePairCaller",
+    "ExactBasePairCaller",
     "AlleleMetric",
     "AllelePrecision",
     "AlleleRecall",

--- a/src/dnanet/evaluation/allele_caller.py
+++ b/src/dnanet/evaluation/allele_caller.py
@@ -4,27 +4,27 @@ Design pattern: **Strategy**
     :class:`AlleleCaller` defines the interface; implementations provide
     different allele-calling algorithms.
 
-Currently implemented are binary segmentation based algorithms, that translates pixel-level segmentation masks
-into allele calls by finding connected components of positive predictions and mapping their positions
-to an allele in the reference panel.
+Currently implemented are prediction-image based algorithms that translate
+pixel-level model outputs into allele calls by finding connected components
+of allele-positive predictions and mapping their positions to an allele in
+the reference panel.
 Implemented are:
     - :class:`NearestBasePairCaller` — Assigns each predicted region to the
       nearest allele by base-pair distance.
-    - :class: `ExactBasePairCaller` - Assigns each predicted region to the
+    - :class:`ExactBasePairCaller` - Assigns each predicted region to the
       allele that has not more than 0.3 base pairs distance.
-
-# TODO: implement multi class allele calling.
 """
 
 from __future__ import annotations
 
 import abc
 from collections import defaultdict
+from typing import Literal
 
 import numpy as np
 from loguru import logger
 
-from dnanet.core import Allele, Marker, Panel
+from dnanet.core import Allele, Marker, Panel, LabelCategory
 
 
 class AlleleCaller(abc.ABC):
@@ -38,24 +38,38 @@ class AlleleCaller(abc.ABC):
         """Translate any input to a sequence of :class:`~dnanet.core.marker.Marker` objects with called alleles."""
 
 
-class FromBinaryMaskCaller(AlleleCaller):
-    """Base class for allele calling strategies from binary segmentation masks.
+class FromSegmentationImageCaller(AlleleCaller):
+    """Base class for allele calling strategies from 2-D prediction images.
 
-    Implementations translate a pixel-level segmentation mask into a
+    Implementations translate a pixel-level prediction image into a
     sequence of :class:`~dnanet.core.marker.Marker` objects with called
-    alleles.
+    alleles. The prediction image can either be:
+    - a binary / probabilistic allele mask, or
+    - a 2-D class-index map where a single class denotes allele signal.
 
     Args:
-        threshold: Probability threshold for positive predictions.
+        threshold: Probability threshold for positive predictions when
+            ``prediction_mode`` resolves to ``"binary"``.
         exclude_non_autosomal: If True, filter out non-autosomal markers from the results.
+        prediction_mode: Representation used by ``prediction_image``.
+        allele_class_index: Class index to treat as allele signal when
+            ``prediction_mode`` resolves to ``"multiclass_labels"``.
     """
     def __init__(
         self,
         threshold: float = 0.5,
         exclude_non_autosomal: bool = False,
+        prediction_mode: Literal["auto", "binary", "multiclass_labels"] = "auto",
     ) -> None:
+        if prediction_mode not in {"auto", "binary", "multiclass_labels"}:
+            raise ValueError(
+                "prediction_mode must be 'auto', 'binary', or 'multiclass_labels', "
+                f"got {prediction_mode!r}."
+            )
         self.threshold = threshold
         self.exclude_non_autosomal = exclude_non_autosomal
+        self.prediction_mode = prediction_mode
+        self.allele_class_index = list(LabelCategory).index(LabelCategory.ALLELE)
 
     def call_alleles(
         self,
@@ -64,10 +78,14 @@ class FromBinaryMaskCaller(AlleleCaller):
         scaler: np.ndarray,
         panel: Panel,
     ) -> tuple[Marker, ...]:
-        """Call alleles from a segmentation prediction.
+        """Call alleles from a prediction image.
 
         Args:
-            prediction_image: (C, L) predicted mask (probabilities or binary).
+            prediction_image: ``(C, L)`` predicted image. Either probabilities /
+            binary values in ``"binary"`` mode or class indices in
+                ``"multiclass_labels"`` mode. In ``"auto"`` mode, float and bool
+                arrays are treated as binary while integer arrays with labels
+                outside ``{0, 1}`` are treated as multiclass.
             signal_image: (C, L) raw EPG signal data (for RFU extraction).
             scaler: (L, ) array mapping scan positions to base pairs.
             panel: Reference panel with allele definitions.
@@ -75,8 +93,9 @@ class FromBinaryMaskCaller(AlleleCaller):
         Returns:
             Tuple of Markers with called alleles.
         """
+        allele_mask = self._prediction_to_allele_mask(prediction_image)
         markers = self._translate_pixels_to_alleles(
-            scaler, prediction_image, signal_image, panel,
+            scaler, allele_mask, signal_image, panel,
         )
 
         if self.exclude_non_autosomal:
@@ -85,14 +104,55 @@ class FromBinaryMaskCaller(AlleleCaller):
 
         return markers
 
+    def _prediction_to_allele_mask(self, prediction_image: np.ndarray) -> np.ndarray:
+        """Normalize supported prediction representations to an allele mask."""
+        prediction = np.asarray(prediction_image)
+        if prediction.ndim != 2:
+            raise ValueError(
+                "prediction_image must be a 2-D array of shape (num_dyes, scanpoints), "
+                f"got shape {prediction.shape}."
+            )
+
+        prediction_mode = self._resolve_prediction_mode(prediction)
+        if prediction_mode == "binary":
+            return prediction >= self.threshold
+
+        return prediction == self.allele_class_index
+
+    def _resolve_prediction_mode(
+        self,
+        prediction: np.ndarray,
+    ) -> Literal["binary", "multiclass_labels"]:
+        """Resolve the effective prediction mode for a normalized array."""
+        if self.prediction_mode != "auto":
+            return self.prediction_mode
+
+        if prediction.dtype == np.bool_ or np.issubdtype(prediction.dtype, np.floating):
+            return "binary"
+
+        if np.issubdtype(prediction.dtype, np.integer):
+            unique_values = np.unique(prediction)
+            if np.all(np.isin(unique_values, (0, 1))):
+                raise ValueError(
+                    "prediction_image is ambiguous in auto mode: integer arrays containing "
+                    "only values {0, 1} could be either binary masks or multiclass labels. "
+                    "Set allele caller prediction_mode explicitly."
+                )
+            return "multiclass_labels"
+
+        raise ValueError(
+            "prediction_image has unsupported dtype for auto mode: "
+            f"{prediction.dtype}."
+        )
+
     def _translate_pixels_to_alleles(
         self,
         scaler: np.ndarray,
-        prediction_image: np.ndarray,
+        allele_mask: np.ndarray,
         signal_image: np.ndarray,
         panel: Panel,
     ) -> tuple[Marker, ...]:
-        """Translate pixel-level segmentation masks to alleles.
+        """Translate an allele-positive mask to allele calls.
 
         For each connected component of positive predictions:
         1. Compute the base pair positions of the prediction (via the scaler).
@@ -103,9 +163,9 @@ class FromBinaryMaskCaller(AlleleCaller):
         loci_dict: dict[tuple[int, str], set[tuple[str, float]]] = defaultdict(set)
         rfus: dict[tuple[str, str, float], int] = defaultdict(int)
 
-        for dye_index, dye_pred in enumerate(prediction_image):
+        for dye_index, dye_pred in enumerate(allele_mask):
             # Find indices of positive predictions.
-            positives = np.where(dye_pred >= self.threshold)[0]
+            positives = np.where(dye_pred)[0]
             if positives.size == 0:
                 logger.debug("No predictions in dye row {}", dye_index)
                 continue
@@ -152,15 +212,20 @@ class FromBinaryMaskCaller(AlleleCaller):
         raise NotImplementedError
 
 
-class NearestBasePairCaller(FromBinaryMaskCaller):
+class NearestBasePairCaller(FromSegmentationImageCaller):
     """Call alleles by nearest base-pair matching."""
 
     def __init__(
             self,
             threshold: float = 0.5,
             exclude_non_autosomal: bool = False,
+            prediction_mode: Literal["auto", "binary", "multiclass_labels"] = "auto",
     ) -> None:
-        super().__init__(threshold, exclude_non_autosomal)
+        super().__init__(
+            threshold=threshold,
+            exclude_non_autosomal=exclude_non_autosomal,
+            prediction_mode=prediction_mode,
+        )
 
     @staticmethod
     def call_allele_from_basepair(
@@ -188,7 +253,7 @@ class NearestBasePairCaller(FromBinaryMaskCaller):
         return dye_mapping[nearest_bp]
 
 
-class ExactBasePairCaller(FromBinaryMaskCaller):
+class ExactBasePairCaller(FromSegmentationImageCaller):
     """Call alleles by comparing predicted base pairs to base pairs of the Panel.
 
     Consider a maximum allowed distance of 0.3 base pairs between the found base pair and the bin center. Demand
@@ -199,8 +264,13 @@ class ExactBasePairCaller(FromBinaryMaskCaller):
             self,
             threshold: float = 0.5,
             exclude_non_autosomal: bool = False,
+            prediction_mode: Literal["auto", "binary", "multiclass_labels"] = "auto",
     ) -> None:
-        super().__init__(threshold, exclude_non_autosomal)
+        super().__init__(
+            threshold=threshold,
+            exclude_non_autosomal=exclude_non_autosomal,
+            prediction_mode=prediction_mode,
+        )
 
     @staticmethod
     def call_allele_from_basepair(

--- a/tests/evaluation/test_allele_caller.py
+++ b/tests/evaluation/test_allele_caller.py
@@ -10,8 +10,12 @@ import pytest
 from dnanet.core.allele import Allele
 from dnanet.core.marker import Marker
 from dnanet.core.panel import Panel
-from dnanet.evaluation.allele_caller import AlleleCaller, NearestBasePairCaller, ExactBasePairCaller, \
-    FromBinaryMaskCaller
+from dnanet.evaluation.allele_caller import (
+    AlleleCaller,
+    ExactBasePairCaller,
+    FromSegmentationImageCaller,
+    NearestBasePairCaller,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -76,12 +80,21 @@ class TestAllelCallerABC:
 
 
 # ---------------------------------------------------------------------------
-# FromBinaryMaskCaller
+# FromPredictionImageCaller
 # ---------------------------------------------------------------------------
 
-class DummyBinaryCaller(FromBinaryMaskCaller):
-    def __init__(self, threshold: float = 0.5, exclude_non_autosomal: bool = False) -> None:
-        super().__init__(threshold, exclude_non_autosomal)
+class DummyPredictionCaller(FromSegmentationImageCaller):
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        exclude_non_autosomal: bool = False,
+        prediction_mode: str = "binary",
+    ) -> None:
+        super().__init__(
+            threshold=threshold,
+            exclude_non_autosomal=exclude_non_autosomal,
+            prediction_mode=prediction_mode,
+        )
 
     @staticmethod
     def call_allele_from_basepair(dye_index: int, base_pair: float, panel: Panel) -> Tuple[str, str]:
@@ -89,9 +102,10 @@ class DummyBinaryCaller(FromBinaryMaskCaller):
             return "MarkerA", "AlleleA"
         return "AMEL", "X"
 
-class TestFromBinaryMaskCaller:
+class TestFromPredictionImageCaller:
+
     def test_returns_tuple_of_markers(self, simple_panel, scaler, signal_image):
-        caller = DummyBinaryCaller()
+        caller = DummyPredictionCaller()
         pred = np.zeros((2, 300), dtype=float)
         pred[0, 99:101] = 1.0
         markers = caller.call_alleles(pred, signal_image, scaler, simple_panel)
@@ -102,11 +116,11 @@ class TestFromBinaryMaskCaller:
         pred = np.zeros((2, 300), dtype=float)
         pred[0, 99:101] = 0.3  # below default threshold
 
-        caller_default = DummyBinaryCaller(threshold=0.5)
+        caller_default = DummyPredictionCaller(threshold=0.5)
         markers_default = caller_default.call_alleles(pred, signal_image, scaler, simple_panel)
         assert len(markers_default) == 0
 
-        caller_low = DummyBinaryCaller(threshold=0.2)
+        caller_low = DummyPredictionCaller(threshold=0.2)
         markers_low = caller_low.call_alleles(pred, signal_image, scaler, simple_panel)
         assert len(markers_low) > 0
 
@@ -115,13 +129,65 @@ class TestFromBinaryMaskCaller:
         pred[0, 99:101] = 1
         pred[1, 99:101] = 1
 
-        caller_exclude_true = DummyBinaryCaller(exclude_non_autosomal=True)
+        caller_exclude_true = DummyPredictionCaller(exclude_non_autosomal=True)
         markers = caller_exclude_true.call_alleles(pred, signal_image, scaler, simple_panel)
         assert [m.name for m in markers] == ["MarkerA"]
 
-        caller_exclude_false = DummyBinaryCaller(exclude_non_autosomal=False)
+        caller_exclude_false = DummyPredictionCaller(exclude_non_autosomal=False)
         markers = caller_exclude_false.call_alleles(pred, signal_image, scaler, simple_panel)
         assert sorted([m.name for m in markers]) == ["AMEL", "MarkerA"]
+
+    def test_multiclass_mode_uses_only_allele_class(self, simple_panel, scaler, signal_image):
+        caller = DummyPredictionCaller(prediction_mode="multiclass_labels")
+        pred = np.zeros((2, 300), dtype=int)
+        pred[0, 99:101] = 1
+        pred[1, 149:151] = 2
+
+        markers = caller.call_alleles(pred, signal_image, scaler, simple_panel)
+
+        assert len(markers) == 1
+        assert markers[0].name == "MarkerA"
+
+
+    def test_invalid_prediction_mode_raises(self):
+        with pytest.raises(ValueError, match="prediction_mode"):
+            DummyPredictionCaller(prediction_mode="guess")
+
+    def test_auto_mode_treats_float_predictions_as_binary(self, simple_panel, scaler, signal_image):
+        caller = DummyPredictionCaller(prediction_mode="auto")
+        pred = np.zeros((2, 300), dtype=float)
+        pred[0, 99:101] = 0.9
+
+        markers = caller.call_alleles(pred, signal_image, scaler, simple_panel)
+
+        assert len(markers) == 1
+        assert markers[0].name == "MarkerA"
+
+    def test_auto_mode_treats_boolean_predictions_as_binary(self, simple_panel, scaler, signal_image):
+        caller = DummyPredictionCaller(prediction_mode="auto")
+        pred = np.zeros((2, 300), dtype=bool)
+        pred[0, 99:101] = True
+
+        markers = caller.call_alleles(pred, signal_image, scaler, simple_panel)
+
+        assert len(markers) == 1
+        assert markers[0].name == "MarkerA"
+
+
+    def test_auto_mode_rejects_ambiguous_integer_predictions(self, simple_panel, scaler, signal_image):
+        caller = DummyPredictionCaller(prediction_mode="auto")
+        pred = np.zeros((2, 300), dtype=int)
+        pred[0, 99:101] = 1
+
+        with pytest.raises(ValueError, match="ambiguous"):
+            caller.call_alleles(pred, signal_image, scaler, simple_panel)
+
+    def test_prediction_image_must_be_2d(self, simple_panel, scaler, signal_image):
+        caller = DummyPredictionCaller()
+        pred = np.zeros((2, 300, 2), dtype=float)
+
+        with pytest.raises(ValueError, match="2-D array"):
+            caller.call_alleles(pred, signal_image, scaler, simple_panel)
 
 # ---------------------------------------------------------------------------
 # NearestBasePairCaller
@@ -149,6 +215,24 @@ class TestNearestBasePairCaller:
         marker_a = [m for m in markers if m.name == "MarkerA"][0]
         allele_names = {a.name for a in marker_a.alleles}
         assert "10" in allele_names
+
+    def test_multiclass_labels_call_only_allele_class(self, simple_panel, scaler, signal_image):
+        caller = NearestBasePairCaller(prediction_mode="multiclass_labels")
+        pred = np.zeros((2, 300), dtype=int)
+        pred[0, 99:101] = 1
+        pred[1, 148:152] = 2
+
+        markers = caller.call_alleles(pred, signal_image, scaler, simple_panel)
+
+        assert {m.name for m in markers} == {"MarkerA"}
+
+    def test_auto_mode_rejects_ambiguous_integer_predictions(self, simple_panel, scaler, signal_image):
+        caller = NearestBasePairCaller(prediction_mode="auto")
+        pred = np.zeros((2, 300), dtype=int)
+        pred[0, 99:101] = 1
+
+        with pytest.raises(ValueError, match="ambiguous"):
+            caller.call_alleles(pred, signal_image, scaler, simple_panel)
 
     def test_rfu_extraction(self, simple_panel, scaler, signal_image):
         caller = NearestBasePairCaller(threshold=0.5)


### PR DESCRIPTION
Adds support to both allele callers for multiclass predictions. Only entries predicted as class allele will be used for allele calling. There is automatic detection for binary/multiclass inputs.