### PR TITLE
Plotting multiclass annotations and predictions

### DIFF
--- a/src/dnanet/evaluation/callbacks/profile_plot.py
+++ b/src/dnanet/evaluation/callbacks/profile_plot.py
@@ -11,7 +11,7 @@ from loguru import logger
 from lightning import Callback
 from matplotlib import pyplot as plt
 
-from dnanet.evaluation.visualization import plot_profile
+from dnanet.evaluation.visualization import coerce_class_map, plot_profile
 from dnanet.evaluation.callbacks.allele_metrics import AlleleMetricsCallback
 
 
@@ -86,17 +86,25 @@ class ProfilePlotCallback(Callback):
             signal = sample_metadata.get("signal_image")
             if signal is None:
                 raise ValueError("Missing signal_image in sample metadata.")
+            signal_for_plot = self._as_2d_array(signal)
 
             annotation = None
             if self.include_annotations and targets is not None:
-                annotation = self._annotation_for_plot(sample_metadata, targets[index])
+                annotation = self._annotation_for_plot(
+                    sample_metadata,
+                    targets[index],
+                    signal_shape=signal_for_plot.shape,
+                )
 
             prediction = None
             if self.include_predictions and preds is not None:
-                prediction = self._as_2d_array(preds[index])
+                prediction = self._prediction_for_plot(
+                    preds[index],
+                    signal_shape=signal_for_plot.shape,
+                )
 
             figure = plot_profile(
-                self._as_2d_array(signal),
+                signal_for_plot,
                 annotation=annotation,
                 prediction=prediction,
                 title=self._title_for_plot(sample_metadata),
@@ -149,13 +157,23 @@ class ProfilePlotCallback(Callback):
         cls,
         sample_metadata: Mapping[str, Any],
         target: np.ndarray,
+        *,
+        signal_shape: tuple[int, int],
     ) -> np.ndarray:
         scanpoint_annotation = sample_metadata.get("scanpoint_annotation")
         if scanpoint_annotation is None:
-            return cls._as_2d_array(target)
+            return coerce_class_map(target, signal_shape=signal_shape, source="annotation")
 
         data = getattr(scanpoint_annotation, "data", scanpoint_annotation)
-        return cls._as_2d_array(data)
+        return coerce_class_map(data, signal_shape=signal_shape, source="annotation")
+
+    @staticmethod
+    def _prediction_for_plot(
+        prediction: np.ndarray,
+        *,
+        signal_shape: tuple[int, int],
+    ) -> np.ndarray:
+        return coerce_class_map(prediction, signal_shape=signal_shape, source="prediction")
 
     @staticmethod
     def _validate_lengths(

--- a/src/dnanet/evaluation/visualization.py
+++ b/src/dnanet/evaluation/visualization.py
@@ -11,14 +11,14 @@ Design pattern: **Pure Functions**
 
 from __future__ import annotations
 
-import math
 from typing import Any, Sequence
 
 import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
+from matplotlib.patches import Patch
 
-from loguru import logger
+from dnanet.core.constants import LabelCategory
 
 # Standard dye channel colors for forensic EPG visualization
 DYE_COLORS: tuple[str, ...] = ("blue", "green", "black", "red", "purple", "orange")
@@ -29,19 +29,16 @@ def plot_profile(
     *,
     annotation: np.ndarray | None = None,
     prediction: np.ndarray | None = None,
-    prediction_as_mask: bool = True,
     title: str | None = None,
     dye_colors: Sequence[str] | None = None,
     figsize: tuple[int, int] = (20, 20),
 ) -> Figure:
-    """Plot a full DNA profile with optional annotations and predictions.
+    """Plot a full DNA profile with optional multiclass annotations.
 
     Args:
         signal: (C, L) EPG signal data (one row per dye channel).
-        annotation: (C, L) binary ground-truth annotation mask.
-        prediction: (C, L) predicted mask (probabilities or binary).
-        prediction_as_mask: If True, show predictions as colored regions.
-            If False, show as an overlaid line.
+        annotation: (C, L) class-index ground-truth annotation map.
+        prediction: (C, L) class-index prediction map.
         title: Optional figure title.
         dye_colors: Colors for each dye channel. Defaults to standard
             forensic dye colors.
@@ -50,34 +47,136 @@ def plot_profile(
     Returns:
         The matplotlib Figure.
     """
+    signal = _coerce_signal(signal)
     colors = dye_colors or DYE_COLORS
-    n_dyes = len(signal)
-    dyes_max = signal.max(axis=1)
+    n_dyes, signal_length = signal.shape
 
-    fig, axs = plt.subplots(n_dyes, figsize=figsize)
-    if n_dyes == 1:
-        axs = [axs]
-
-    # Plot signal
-    _plot_lines(axs, signal, colors)
-
-    # Plot annotation as green background regions
+    annotation_map = None
     if annotation is not None:
-        _plot_segmentation_mask(axs, annotation, dyes_max, color="green", alpha=0.4)
+        annotation_map = coerce_class_map(
+            annotation,
+            signal_shape=signal.shape,
+            source="annotation",
+        )
 
-    # Plot prediction
+    prediction_map = None
     if prediction is not None:
-        if prediction_as_mask:
-            pred_binary = (prediction > 0.5).astype(int)
-            _plot_segmentation_mask(axs, pred_binary, dyes_max, color="orange", alpha=0.5)
-        else:
-            _plot_lines(axs, prediction, "orange", scale_to=dyes_max)
+        prediction_map = coerce_class_map(
+            prediction,
+            signal_shape=signal.shape,
+            source="prediction",
+        )
+
+    fig, axes = plt.subplots(
+        n_dyes * 3,
+        1,
+        figsize=figsize,
+        sharex=True,
+        gridspec_kw={"height_ratios": [6, 1, 1] * n_dyes},
+    )
+    axes = np.atleast_1d(axes).tolist()
+    signal_axes = axes[0::3]
+    annotation_axes = axes[1::3]
+    prediction_axes = axes[2::3]
+
+    _plot_lines(signal_axes, signal, colors)
+    for signal_ax in signal_axes:
+        signal_ax.set_xlim(-0.5, signal_length - 0.5)
+        signal_ax.margins(x=0)
+        signal_ax.spines["top"].set_visible(False)
+        signal_ax.spines["right"].set_visible(False)
+
+    present_classes: set[int] = set()
+    present_classes.update(
+        _plot_class_tracks(annotation_axes, annotation_map, lane_label="Ann")
+    )
+    present_classes.update(
+        _plot_class_tracks(prediction_axes, prediction_map, lane_label="Pred")
+    )
 
     if title:
         fig.suptitle(title, fontsize=16)
 
-    fig.tight_layout()
+    if present_classes:
+        fig.legend(
+            handles=[
+                Patch(
+                    facecolor=LabelCategory.from_index(class_idx).color,
+                    edgecolor="none",
+                    label=LabelCategory.from_index(class_idx).display_name,
+                )
+                for class_idx in sorted(present_classes)
+            ],
+            loc="upper right",
+        )
+
+    prediction_axes[-1].set_xlabel("Scanpoint")
+    fig.tight_layout(rect=(0, 0, 1, 0.98))
     return fig
+
+
+def coerce_class_map(
+    data: np.ndarray,
+    *,
+    signal_shape: tuple[int, int],
+    source: str,
+) -> np.ndarray:
+    """Normalize plotting labels to a 2-D class-index map.
+
+    Supports:
+      - (C, L) integer class maps
+      - (K, C, L) class-first logits/one-hot arrays
+      - (C, L, K) class-last logits/one-hot arrays
+      - singleton class/channel variants of the shapes above
+
+    Binary probability maps are thresholded at 0.5 only when there is a
+    single class channel. Multiclass arrays are reduced with argmax.
+    """
+    result = np.asarray(data)
+
+    if result.ndim == 1:
+        result = result[np.newaxis, :]
+
+    if result.ndim == 2:
+        return _coerce_integer_class_map(
+            result,
+            signal_shape=signal_shape,
+            source=source,
+            threshold_binary=source == "prediction",
+        )
+
+    if result.ndim == 3 and result.shape[1:] == signal_shape:
+        if result.shape[0] == 1:
+            return _coerce_integer_class_map(
+                result[0],
+                signal_shape=signal_shape,
+                source=source,
+                threshold_binary=source == "prediction",
+            )
+        return _coerce_integer_class_map(
+            result.argmax(axis=0),
+            signal_shape=signal_shape,
+            source=source,
+        )
+
+    if result.ndim == 3 and result.shape[:2] == signal_shape:
+        if result.shape[-1] == 1:
+            return _coerce_integer_class_map(
+                result[..., 0],
+                signal_shape=signal_shape,
+                source=source,
+                threshold_binary=source == "prediction",
+            )
+        return _coerce_integer_class_map(
+            result.argmax(axis=-1),
+            signal_shape=signal_shape,
+            source=source,
+        )
+
+    raise ValueError(
+        f"{source} must have shape {signal_shape}, (classes, *{signal_shape}), "
+        f"or (*{signal_shape}, classes); got {result.shape}."
+    )
 
 
 def plot_profile_marker(
@@ -127,20 +226,24 @@ def plot_profile_marker(
 
     if annotation is not None:
         ann_slice = annotation[dye_row, scan_slice]
-        ax.fill_between(
-            np.arange(len(ann_slice)), 0, marker_signal.max(),
-            where=ann_slice.flatten() == 1,
-            color="green", alpha=0.4,
-            transform=ax.get_xaxis_transform(),
+        _plot_segmentation_mask(
+            [ax],
+            ann_slice[np.newaxis, :],
+            color="green",
+            alpha=0.55,
+            y_range=(0.88, 0.94),
+            min_width=3,
         )
 
     if prediction is not None:
         pred_slice = prediction[dye_row, scan_slice]
-        ax.fill_between(
-            np.arange(len(pred_slice)), 0, marker_signal.max(),
-            where=(pred_slice > 0.5).astype(int).flatten(),
-            color="orange", alpha=0.4,
-            transform=ax.get_xaxis_transform(),
+        _plot_segmentation_mask(
+            [ax],
+            ((pred_slice > 0.5).astype(int))[np.newaxis, :],
+            color="orange",
+            alpha=0.75,
+            y_range=(0.95, 1.0),
+            min_width=3,
         )
 
     if title:
@@ -153,6 +256,20 @@ def plot_profile_marker(
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+def _coerce_signal(signal: np.ndarray) -> np.ndarray:
+    """Return signal as a 2-D ``(num_dyes, scanpoints)`` array."""
+    result = np.asarray(signal)
+    if result.ndim == 1:
+        result = result[np.newaxis, :]
+    if result.ndim == 3 and result.shape[-1] == 1:
+        result = result[..., 0]
+    if result.ndim != 2:
+        raise ValueError(
+            f"signal must be a 2-D array of shape (num_dyes, scanpoints); got {result.shape}."
+        )
+    return result
+
 
 def _plot_lines(
     axs: Sequence[plt.Axes],
@@ -184,26 +301,179 @@ def _plot_lines(
         axs[i].plot(y, c=c, alpha=alpha)
 
 
+def _plot_class_tracks(
+    axs: Sequence[plt.Axes],
+    class_map: np.ndarray | None,
+    *,
+    lane_label: str,
+) -> set[int]:
+    """Plot per-class mini-lanes and return the set of drawn class indices."""
+    present_classes: set[int] = set()
+
+    for ax in axs:
+        ax.set_ylim(0.0, 1.0)
+        ax.set_yticks([])
+        ax.set_ylabel(lane_label, rotation=0, labelpad=18, va="center")
+        ax.margins(x=0)
+        ax.spines["top"].set_visible(False)
+        ax.spines["right"].set_visible(False)
+        ax.spines["left"].set_visible(False)
+
+    if class_map is None:
+        return present_classes
+
+    for ax, class_row in zip(axs, class_map, strict=True):
+        for start, end, class_idx in _iter_class_spans(class_row):
+            category = LabelCategory.from_index(class_idx)
+            width = end - start
+            present_classes.add(class_idx)
+
+            if width == 1:
+                ax.scatter(
+                    [start],
+                    [0.5],
+                    marker="s",
+                    s=36,
+                    color=category.color,
+                    edgecolors="black",
+                    linewidths=0.6,
+                    zorder=3,
+                )
+            else:
+                ax.barh(
+                    y=0.5,
+                    width=width,
+                    left=start - 0.5,
+                    height=0.7,
+                    color=category.color,
+                    edgecolor="none",
+                    align="center",
+                )
+
+    return present_classes
+
+
+def _coerce_integer_class_map(
+    class_map: np.ndarray,
+    *,
+    signal_shape: tuple[int, int],
+    source: str,
+    threshold_binary: bool = False,
+) -> np.ndarray:
+    """Validate a 2-D class map and convert it to integer indices."""
+    if class_map.shape != signal_shape:
+        raise ValueError(
+            f"{source} must match signal shape {signal_shape}; got {class_map.shape}."
+        )
+
+    rounded = np.rint(class_map)
+    if np.allclose(class_map, rounded):
+        class_indices = rounded.astype(np.int32, copy=False)
+    elif threshold_binary:
+        class_indices = (np.asarray(class_map) > 0.5).astype(np.int32, copy=False)
+    else:
+        raise ValueError(
+            f"{source} must be an integer class map for plotting; got non-integer values."
+        )
+
+    num_classes = len(LabelCategory)
+    if np.any(class_indices < 0) or np.any(class_indices >= num_classes):
+        raise ValueError(
+            f"{source} class indices must be in [0, {num_classes}); "
+            f"got range [{class_indices.min()}, {class_indices.max()}]."
+        )
+
+    return class_indices
+
+
+def _iter_class_spans(class_row: np.ndarray) -> list[tuple[int, int, int]]:
+    """Return contiguous non-zero class spans as ``(start, end, class_idx)``."""
+    labels = np.asarray(class_row).astype(np.int32, copy=False).flatten()
+    if labels.size == 0:
+        return []
+
+    spans: list[tuple[int, int, int]] = []
+    start = 0
+    current = int(labels[0])
+
+    for index in range(1, labels.size + 1):
+        if index < labels.size and int(labels[index]) == current:
+            continue
+
+        if current != 0:
+            spans.append((start, index, current))
+
+        if index < labels.size:
+            start = index
+            current = int(labels[index])
+
+    return spans
+
+
 def _plot_segmentation_mask(
     axs: Sequence[plt.Axes],
     mask: np.ndarray,
-    max_values: np.ndarray,
     color: str = "green",
     alpha: float = 0.5,
+    y_range: tuple[float, float] = (0.0, 1.0),
+    min_width: int = 1,
 ) -> None:
-    """Plot segmentation mask as colored background regions.
+    """Plot segmentation mask as colored scanpoint tracks.
 
     Args:
         axs: One axis per dye channel.
         mask: (C, L) binary mask.
-        max_values: Max signal value per dye (for fill height).
         color: Fill color.
         alpha: Fill alpha.
+        y_range: Vertical band in axis coordinates.
+        min_width: Minimum visible width of a positive region in scanpoints.
     """
-    for i, (dye_mask, max_val) in enumerate(zip(mask, max_values)):
-        axs[i].fill_between(
-            np.arange(len(dye_mask)), 0, max_val,
-            where=dye_mask.flatten() == 1,
-            color=color, alpha=alpha,
-            transform=axs[i].get_xaxis_transform(),
-        )
+    for ax, dye_mask in zip(axs, mask, strict=True):
+        for start, end in _iter_mask_spans(dye_mask, min_width=min_width):
+            ax.axvspan(
+                start,
+                end,
+                ymin=y_range[0],
+                ymax=y_range[1],
+                facecolor=color,
+                edgecolor="none",
+                alpha=alpha,
+            )
+
+
+def _iter_mask_spans(
+    mask_row: np.ndarray,
+    *,
+    min_width: int = 1,
+) -> list[tuple[float, float]]:
+    """Return contiguous positive mask spans with optional display widening."""
+    binary = np.asarray(mask_row).astype(bool).flatten()
+    if binary.size == 0 or not np.any(binary):
+        return []
+
+    padded = np.pad(binary.astype(np.int8), (1, 1))
+    changes = np.diff(padded)
+    starts = np.flatnonzero(changes == 1)
+    ends = np.flatnonzero(changes == -1)
+    spans: list[tuple[float, float]] = []
+
+    for start, end in zip(starts, ends, strict=True):
+        width = end - start
+        if width < min_width:
+            missing = min_width - width
+            left_extra = missing // 2
+            right_extra = missing - left_extra
+            start = max(0, start - left_extra)
+            end = min(binary.size, end + right_extra)
+
+            # If span hit boundary, rebalance to keep requested minimum width.
+            width = end - start
+            if width < min_width:
+                if start == 0:
+                    end = min(binary.size, min_width)
+                else:
+                    start = max(0, binary.size - min_width)
+
+        spans.append((float(start), float(end)))
+
+    return spans

--- a/src/dnanet/evaluation/visualization.py
+++ b/src/dnanet/evaluation/visualization.py
@@ -67,17 +67,33 @@ def plot_profile(
             source="prediction",
         )
 
+    track_names = ["signal"]
+    track_height_ratios = {"signal": 6, "annotation": 1, "prediction": 1}
+    if annotation_map is not None:
+        track_names.append("annotation")
+    if prediction_map is not None:
+        track_names.append("prediction")
+
+    num_tracks = len(track_names)
     fig, axes = plt.subplots(
-        n_dyes * 3,
+        n_dyes * num_tracks,
         1,
         figsize=figsize,
         sharex=True,
-        gridspec_kw={"height_ratios": [6, 1, 1] * n_dyes},
+        gridspec_kw={
+            "height_ratios": [
+                track_height_ratios[track_name]
+                for _ in range(n_dyes)
+                for track_name in track_names
+            ],
+        },
     )
     axes = np.atleast_1d(axes).tolist()
-    signal_axes = axes[0::3]
-    annotation_axes = axes[1::3]
-    prediction_axes = axes[2::3]
+    axes_by_track = {
+        track_name: axes[track_index::num_tracks]
+        for track_index, track_name in enumerate(track_names)
+    }
+    signal_axes = axes_by_track["signal"]
 
     _plot_lines(signal_axes, signal, colors)
     for signal_ax in signal_axes:
@@ -87,12 +103,22 @@ def plot_profile(
         signal_ax.spines["right"].set_visible(False)
 
     present_classes: set[int] = set()
-    present_classes.update(
-        _plot_class_tracks(annotation_axes, annotation_map, lane_label="Ann")
-    )
-    present_classes.update(
-        _plot_class_tracks(prediction_axes, prediction_map, lane_label="Pred")
-    )
+    if annotation_map is not None:
+        present_classes.update(
+            _plot_class_tracks(
+                axes_by_track["annotation"],
+                annotation_map,
+                lane_label="Ann",
+            )
+        )
+    if prediction_map is not None:
+        present_classes.update(
+            _plot_class_tracks(
+                axes_by_track["prediction"],
+                prediction_map,
+                lane_label="Pred",
+            )
+        )
 
     if title:
         fig.suptitle(title, fontsize=16)
@@ -110,7 +136,7 @@ def plot_profile(
             loc="upper right",
         )
 
-    prediction_axes[-1].set_xlabel("Scanpoint")
+    axes[-1].set_xlabel("Scanpoint")
     fig.tight_layout(rect=(0, 0, 1, 0.98))
     return fig
 

--- a/tests/evaluation/test_profile_plot_callback.py
+++ b/tests/evaluation/test_profile_plot_callback.py
@@ -29,10 +29,10 @@ def close_figures():
 
 
 def _batch(size: int = 3) -> tuple[tuple[torch.Tensor, torch.Tensor, list[dict]], dict]:
-    targets = torch.zeros((size, 1, 4, 1), dtype=torch.float32)
-    targets[:, :, 1:3, :] = 1
-    preds = torch.zeros((size, 1, 4, 1), dtype=torch.float32)
-    preds[:, :, 2:4, :] = 0.9
+    targets = torch.zeros((size, 3, 1, 4), dtype=torch.float32)
+    targets[:, 1, 0, 1:3] = 1
+    preds = torch.zeros((size, 3, 1, 4), dtype=torch.float32)
+    preds[:, 2, 0, 2:4] = 0.9
     metadata = [
         {
             "path": f"sample {index}.hid",
@@ -150,7 +150,7 @@ def test_profile_plot_callback_passes_annotations_and_predictions(
     assert calls[0]["annotation"].shape == (1, 4)
     assert calls[0]["prediction"].shape == (1, 4)
     np.testing.assert_array_equal(calls[0]["annotation"], np.array([[0, 1, 1, 0]]))
-    np.testing.assert_allclose(calls[0]["prediction"], np.array([[0, 0, 0.9, 0.9]]))
+    np.testing.assert_array_equal(calls[0]["prediction"], np.array([[0, 0, 2, 2]]))
 
 
 def test_profile_plot_callback_requires_predictions_when_enabled(tmp_path):
@@ -168,3 +168,32 @@ def test_profile_plot_callback_requires_predictions_when_enabled(tmp_path):
             batch=batch,
             batch_idx=0,
         )
+
+
+def test_profile_plot_callback_thresholds_binary_probability_predictions(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_plot_profile(signal, *, annotation=None, prediction=None, **kwargs):
+        del signal, annotation, kwargs
+        calls.append(prediction)
+        return plt.figure()
+
+    monkeypatch.setattr(profile_plot_module, "plot_profile", fake_plot_profile)
+    callback = ProfilePlotCallback(include_predictions=True, num_profiles=1)
+
+    targets = torch.zeros((1, 1, 4, 1), dtype=torch.float32)
+    preds = torch.tensor([[[0.2], [0.6], [0.49], [0.51]]], dtype=torch.float32).unsqueeze(0)
+    metadata = [{"path": "sample 0.hid", "signal_image": np.ones((1, 4, 1), dtype=np.float32)}]
+    batch = torch.zeros((1, 1, 4, 1), dtype=torch.float32), targets, metadata
+    outputs = {"preds": preds}
+
+    callback.on_test_epoch_start(FakeTrainer(tmp_path), FakeModule())
+    callback.on_test_batch_end(
+        FakeTrainer(tmp_path),
+        FakeModule(),
+        outputs=outputs,
+        batch=batch,
+        batch_idx=0,
+    )
+
+    np.testing.assert_array_equal(calls[0], np.array([[0, 1, 0, 1]]))

--- a/tests/evaluation/test_visualization.py
+++ b/tests/evaluation/test_visualization.py
@@ -54,17 +54,17 @@ class TestPlotProfile:
     def test_signal_only(self, signal_5dye):
         fig = plot_profile(signal_5dye)
         assert isinstance(fig, Figure)
-        assert len(fig.axes) == 15
+        assert len(fig.axes) == 5
 
     def test_with_annotation(self, signal_5dye, annotation_5dye):
         fig = plot_profile(signal_5dye, annotation=annotation_5dye)
         assert isinstance(fig, Figure)
-        assert len(fig.axes) == 15
+        assert len(fig.axes) == 10
 
     def test_with_prediction(self, signal_5dye, prediction_5dye):
         fig = plot_profile(signal_5dye, prediction=prediction_5dye)
         assert isinstance(fig, Figure)
-        assert len(fig.axes) == 15
+        assert len(fig.axes) == 10
 
     def test_with_title(self, signal_5dye):
         fig = plot_profile(signal_5dye, title="Test Profile")
@@ -98,7 +98,7 @@ class TestPlotProfile:
         signal = np.random.default_rng(1).random((1, 100))
         fig = plot_profile(signal)
         assert isinstance(fig, Figure)
-        assert len(fig.axes) == 3
+        assert len(fig.axes) == 1
 
     def test_annotation_and_prediction_use_separate_tracks(self):
         signal = np.random.default_rng(7).random((1, 100))

--- a/tests/evaluation/test_visualization.py
+++ b/tests/evaluation/test_visualization.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from matplotlib.colors import to_rgba
 from matplotlib.figure import Figure
 
+from dnanet.core.constants import LabelCategory
 from dnanet.evaluation.visualization import (
     DYE_COLORS,
     plot_profile,
@@ -28,19 +30,19 @@ def signal_5dye() -> np.ndarray:
 
 @pytest.fixture
 def annotation_5dye() -> np.ndarray:
-    """Binary annotation mask matching signal_5dye."""
-    ann = np.zeros((5, 200), dtype=float)
-    ann[0, 30:50] = 1
-    ann[1, 80:100] = 1
+    """Multiclass annotation map matching signal_5dye."""
+    ann = np.zeros((5, 200), dtype=np.int32)
+    ann[0, 30:50] = list(LabelCategory).index(LabelCategory.ALLELE)
+    ann[1, 80:100] = list(LabelCategory).index(LabelCategory.STUTTER)
     return ann
 
 
 @pytest.fixture
 def prediction_5dye() -> np.ndarray:
-    """Probability prediction mask matching signal_5dye."""
-    pred = np.random.default_rng(123).random((5, 200)).astype(np.float32) * 0.3
-    pred[0, 30:50] = 0.9
-    pred[1, 80:100] = 0.8
+    """Multiclass prediction map matching signal_5dye."""
+    pred = np.zeros((5, 200), dtype=np.int32)
+    pred[0, 30:50] = list(LabelCategory).index(LabelCategory.PULL_UP)
+    pred[1, 80:100] = list(LabelCategory).index(LabelCategory.BLEED_THROUGH)
     return pred
 
 
@@ -52,27 +54,17 @@ class TestPlotProfile:
     def test_signal_only(self, signal_5dye):
         fig = plot_profile(signal_5dye)
         assert isinstance(fig, Figure)
-        assert len(fig.axes) == 5
+        assert len(fig.axes) == 15
 
     def test_with_annotation(self, signal_5dye, annotation_5dye):
         fig = plot_profile(signal_5dye, annotation=annotation_5dye)
         assert isinstance(fig, Figure)
+        assert len(fig.axes) == 15
 
-    def test_with_prediction_mask(self, signal_5dye, prediction_5dye):
-        fig = plot_profile(
-            signal_5dye,
-            prediction=prediction_5dye,
-            prediction_as_mask=True,
-        )
+    def test_with_prediction(self, signal_5dye, prediction_5dye):
+        fig = plot_profile(signal_5dye, prediction=prediction_5dye)
         assert isinstance(fig, Figure)
-
-    def test_with_prediction_line(self, signal_5dye, prediction_5dye):
-        fig = plot_profile(
-            signal_5dye,
-            prediction=prediction_5dye,
-            prediction_as_mask=False,
-        )
-        assert isinstance(fig, Figure)
+        assert len(fig.axes) == 15
 
     def test_with_title(self, signal_5dye):
         fig = plot_profile(signal_5dye, title="Test Profile")
@@ -95,11 +87,66 @@ class TestPlotProfile:
             title="Full Profile",
         )
         assert isinstance(fig, Figure)
+        assert [text.get_text() for text in fig.legends[0].get_texts()] == [
+            "Allele",
+            "Stutter",
+            "Pull Up",
+            "Bleed Through",
+        ]
 
     def test_single_dye(self):
         signal = np.random.default_rng(1).random((1, 100))
         fig = plot_profile(signal)
         assert isinstance(fig, Figure)
+        assert len(fig.axes) == 3
+
+    def test_annotation_and_prediction_use_separate_tracks(self):
+        signal = np.random.default_rng(7).random((1, 100))
+        annotation = np.zeros((1, 100), dtype=np.int32)
+        prediction = np.zeros((1, 100), dtype=np.int32)
+        annotation[0, 20:23] = list(LabelCategory).index(LabelCategory.ALLELE)
+        prediction[0, 40:43] = list(LabelCategory).index(LabelCategory.STUTTER)
+
+        fig = plot_profile(signal, annotation=annotation, prediction=prediction)
+
+        assert len(fig.axes[1].patches) == 1
+        assert len(fig.axes[2].patches) == 1
+
+    def test_single_scanpoint_annotation_is_rendered_as_square(self):
+        signal = np.random.default_rng(11).random((1, 100))
+        annotation = np.zeros((1, 100), dtype=np.int32)
+        annotation[0, 10] = list(LabelCategory).index(LabelCategory.ALLELE)
+
+        fig = plot_profile(signal, annotation=annotation)
+
+        assert len(fig.axes[1].patches) == 0
+        assert len(fig.axes[1].collections) == 1
+        assert tuple(fig.axes[1].collections[0].get_edgecolors()[0]) == to_rgba("black")
+
+    def test_multi_scanpoint_annotation_is_rendered_as_bar(self):
+        signal = np.random.default_rng(13).random((1, 100))
+        annotation = np.zeros((1, 100), dtype=np.int32)
+        annotation[0, 10:14] = list(LabelCategory).index(LabelCategory.ALLELE)
+
+        fig = plot_profile(signal, annotation=annotation)
+
+        assert len(fig.axes[1].patches) == 1
+        assert len(fig.axes[1].collections) == 0
+
+    def test_multiclass_uses_label_category_colors(self):
+        signal = np.random.default_rng(17).random((1, 100))
+        annotation = np.zeros((1, 100), dtype=np.int32)
+        prediction = np.zeros((1, 100), dtype=np.int32)
+        annotation[0, 10:14] = list(LabelCategory).index(LabelCategory.ALLELE)
+        prediction[0, 40] = list(LabelCategory).index(LabelCategory.STUTTER)
+
+        fig = plot_profile(signal, annotation=annotation, prediction=prediction)
+
+        ann_patch = fig.axes[1].patches[0]
+        pred_square = fig.axes[2].collections[0]
+
+        assert ann_patch.get_facecolor() == to_rgba(LabelCategory.ALLELE.color)
+        assert tuple(pred_square.get_facecolors()[0]) == to_rgba(LabelCategory.STUTTER.color)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Changes the plot_profile function to have support for multiclass predictions and annotations. This is done by adding a small lane under every dye with the predictions and a lane with annotations. The width of the bars matches the width of the annotations/predictions. When the width is 1 (for top annotations), a square with a black outline is drawn for readability. Colors are used to indicate the different classes and a legend is shown. 

Only integer annotations and predictions are accepted, plotting the prediction probability is not supported anymore. Predictions are converted to 0 or 1 using a threshold of 0.5 before plotting.

An example is shown below

<img width="2997" height="1495" alt="image" src="https://github.com/user-attachments/assets/ac75d963-9924-4616-b778-03d13965a8bf" />
