### PR TITLE
Also cut the scanpoint annotation array resulting from spannotation

### DIFF
--- a/src/dnanet/data/hid_dataset.py
+++ b/src/dnanet/data/hid_dataset.py
@@ -366,7 +366,6 @@ class HIDDataset(Dataset, TransformableDataset):
                     allele_annotation=annotation,
                     adjusted_panel=current_panel,
                     scaler=image.scaler,
-                    include_size_standard=self.include_size_standard,
                     scaling_strategy=self._scaling,
                     profile_data=image.data if self.adjustment_of_annotations else None,
                     adjustment_type=self.adjustment_of_annotations,
@@ -399,6 +398,9 @@ class HIDDataset(Dataset, TransformableDataset):
             else:
                 scanpoint_annotation = annotation
 
+            if scanpoint_annotation and not self.include_size_standard:
+                scanpoint_annotation = ScanpointAnnotation(scanpoint_annotation.data[:-1])
+
             image.annotation = scanpoint_annotation
 
             if image.annotation is None and not self.allow_missing_annotations:
@@ -420,7 +422,6 @@ class HIDDataset(Dataset, TransformableDataset):
         allele_annotation: AlleleAnnotation,
         adjusted_panel: Panel,
         scaler: np.ndarray,
-        include_size_standard: bool,
         scaling_strategy: ScalingStrategy,
         profile_data: np.ndarray | None = None,
         adjustment_type: str | None = None,
@@ -440,10 +441,8 @@ class HIDDataset(Dataset, TransformableDataset):
         inserted at the boundary between any adjacent or overlapping bins so
         that isolated islands of 1s are always preserved.
         """
-        kit_num_dyes = scaling_strategy.kit.num_dyes
-        num_dyes = kit_num_dyes if include_size_standard else kit_num_dyes - 1
         scanpoint_annotation = np.zeros(
-            (num_dyes, scaling_strategy.scanpoint_resolution),
+            (scaling_strategy.kit.num_dyes, scaling_strategy.scanpoint_resolution),
             dtype=np.int8,
         )
 

--- a/tests/integration/test_annotations.py
+++ b/tests/integration/test_annotations.py
@@ -123,7 +123,6 @@ class TestParseCalledAlleles:
             allele_annotation=sample_annotation,
             adjusted_panel=nfi_rnd_kit.panel,
             scaler=image.scaler,
-            include_size_standard=False,
             scaling_strategy=nfi_rnd_kit,
         ).data
 
@@ -140,13 +139,15 @@ class TestParseCalledAlleles:
             allele_annotation=sample_annotation,
             adjusted_panel=adjusted_panel,
             scaler=image.scaler,
-            include_size_standard=False,
             scaling_strategy=nfi_rnd_kit,
         ).data
 
         reference = np.load(RD_DIR / '1A2_A01_01_annotation.npy')
         if reference.ndim == 3:
             reference = reference[:, :, 0]
+
+        default_scanpoint = default_scanpoint[:-1]
+        adjusted_scanpoint = adjusted_scanpoint[:-1]
 
         default_diff = int(np.abs(default_scanpoint.astype(int) - reference.astype(int)).sum())
         adjusted_diff = int(np.abs(adjusted_scanpoint.astype(int) - reference.astype(int)).sum())


### PR DESCRIPTION
When include_size_standard is set to False, the size standard lane for the scanpoint annotation resulting from allele annotation was already removed. This was however not done when we are parsing from spannotations. 