### PR TITLE
Fixes in NFI data strategies

### DIFF
--- a/src/dnanet/data/strategies/datasets/nfi_casework.py
+++ b/src/dnanet/data/strategies/datasets/nfi_casework.py
@@ -4,7 +4,7 @@ Handles the NFI Zaaksdata
 
 Warning:
     This strategy is developed specifically for our in-house casework.
-    Altough file-collection and caching logic might be of use for your own implementation,
+    Although file-collection and caching logic might be of use for your own implementation,
     using this strategy for other/your own data does not make sense.
 
     Please see the documentation about developing your own strategy, or use the two other strategies for the open-source data.
@@ -61,7 +61,7 @@ class NFICaseStrategy(DatasetStrategy):
         Available annotation types:
         - AT: only include profiles with a "high" analytical threshold (allele annotation)
         - LT: only include profiles with a low threshold (allele annotation)
-        - ATLT: include profiles with either a high or low threshold (allele annotation)
+        - ATLT: include profiles with either a high or low threshold, meaning all annotations are included (allele annotation)
         - span: include profiles with a span annotation (scanpoint annotation)
         """
         super().__init__()
@@ -211,13 +211,17 @@ class NFICaseStrategy(DatasetStrategy):
             annotations_folder = path / 'annotations'
             annotation_mapping = cls.find_annotation_files(annotations_folder)
 
-            # find what run_id corresponds to what annotation type (AT/LT/init) from runid_type.csv
-            run_id_path = path / 'runid_type.csv'
-            if not run_id_path.exists():
-                raise FileNotFoundError(f'Could not find runid_type.csv in {path}')
-            run_id_type_mapping = {
-                row[0]: row[1] for row in np.genfromtxt(run_id_path, delimiter=',', dtype=str)
-            }
+            if annotation_type == 'ATLT':
+                # for ATLT, we include all annotations, there do not need a runid type mapping.
+                run_id_type_mapping = dict()
+            else:
+                # find what run_id corresponds to what annotation type (AT/LT/init) from runid_type.csv
+                run_id_path = path / 'runid_type.csv'
+                if not run_id_path.exists():
+                    raise FileNotFoundError(f'Could not find runid_type.csv in {path}')
+                run_id_type_mapping = {
+                    row[0]: row[1] for row in np.genfromtxt(run_id_path, delimiter=',', dtype=str)
+                }
 
             def resolve_annotation(hid_file: Path) -> AlleleAnnotation | None:
                 run_id = hid_file.stem.split('_')[0]

--- a/src/dnanet/data/strategies/datasets/nfi_rnd.py
+++ b/src/dnanet/data/strategies/datasets/nfi_rnd.py
@@ -385,8 +385,8 @@ class NFIRnDStrategy(DatasetStrategy):
             List of Markers with their alleles, or ``None`` if not found.
         """
         if os.stat(annotation_source).st_size == 0:
-            logger.debug('Empty annotation file: {}', annotation_source)
-            raise RuntimeError('Annotations file is emtpy')
+            logger.debug('Skipping empty annotation file: {}', annotation_source)
+            return {}
 
         annotation_mapping: Dict[str, AlleleAnnotation] = {}
         with open(annotation_source, 'r') as f:
@@ -396,7 +396,8 @@ class NFIRnDStrategy(DatasetStrategy):
             delimiter, allele_cols, height_cols = header_result
 
             reader = csv.reader(f, delimiter=delimiter)
-            for sample, rows in groupby(reader, lambda row: row[0]):
+            filtered = (row for row in reader if row)  # skips empty lines
+            for sample, rows in groupby(filtered, lambda row: row[0]):
                 sample_annotation = cls._parse_sample_annotations(
                     rows, allele_cols, height_cols, scaling_strategy
                 )


### PR DESCRIPTION
* Fix missing runid type csv that we do not need when dealing with ATLT
* Skip empty annotations file by continuing instead of raising error
* Strip empty lines from annotations file, that earlier resulted in an index error.